### PR TITLE
Add authentication and authorization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.6.1
+- added optional authentication to an Active Directory server for all 
+  REST endpoints
+
+
 ## 0.6.0
 - added functionality to load dynamic protocol jars in both cli as well
   as service

--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ apply plugin: 'war'
 
 war {
     baseName = 'remrem-generate'
-    version =  '0.6.0'
+    version =  '0.6.1'
 }
 
 

--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ apply plugin: 'war'
 
 war {
     baseName = 'remrem-generate'
-    version =  '0.6.1'
+    version =  '0.6.2'
 }
 
 

--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ apply plugin: 'war'
 
 war {
     baseName = 'remrem-generate'
-    version =  '0.5.9'
+    version =  '0.5.10'
 }
 
 
@@ -128,11 +128,17 @@ dependencies {
     compile("org.springframework.boot:spring-boot-starter-actuator:$sprintBootVersion")
     compile "org.springframework.boot:spring-boot:$sprintBootVersion"
     // end::actuator[]
+
+    //Authentication
+    compile("org.springframework.boot:spring-boot-starter-security")
+    compile("org.springframework.security:spring-security-ldap")
+    compile("org.apache.directory.server:apacheds-server-jndi:1.5.5")
     
      //ServletException requires compile time servlet dependency but it causes problems
     //when deployed if exist on war run time.. hence provided but also compileOnly
     compileOnly("org.springframework.boot:spring-boot-starter-tomcat")
     providedRuntime("org.springframework.boot:spring-boot-starter-tomcat")
+    testCompile("org.springframework.boot:spring-boot-starter-tomcat")
 
     //Injectable Message Library and its Implementation
     compile 'com.github.Ericsson:eiffel-remrem-shared:0.1.4'

--- a/src/integration-test/java/com/ericsson/eiffel/remrem/generate/EiffelSemanticsCli.java
+++ b/src/integration-test/java/com/ericsson/eiffel/remrem/generate/EiffelSemanticsCli.java
@@ -1,26 +1,27 @@
 package com.ericsson.eiffel.remrem.generate;
 
-import java.io.ByteArrayOutputStream;
-import java.io.File;
-import java.io.IOException;
-import java.io.PrintStream;
-
+import com.ericsson.eiffel.remrem.generate.cli.CLI;
+import com.ericsson.eiffel.remrem.generate.cli.CLIExitCodes;
+import com.ericsson.eiffel.remrem.generate.cli.CLIOptions;
+import com.ericsson.eiffel.remrem.generate.config.PropertiesConfig;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.boot.test.context.ConfigFileApplicationContextInitializer;
 
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.IOException;
+import java.io.PrintStream;
+
 import static org.junit.Assert.assertTrue;
 
-import com.ericsson.eiffel.remrem.generate.cli.CLI;
-import com.ericsson.eiffel.remrem.generate.cli.CLIExitCodes;
-import com.ericsson.eiffel.remrem.generate.cli.CLIOptions;
-import com.ericsson.eiffel.remrem.generate.config.PropertiesConfig;
-
+@ActiveProfiles("integration-test")
 @RunWith(SpringRunner.class)
 @ContextConfiguration(initializers=ConfigFileApplicationContextInitializer.class, locations={"/EiffelSemanticsCli-context.xml"})
 public class EiffelSemanticsCli {

--- a/src/integration-test/java/com/ericsson/eiffel/remrem/generate/config/SecurityConfig.java
+++ b/src/integration-test/java/com/ericsson/eiffel/remrem/generate/config/SecurityConfig.java
@@ -1,0 +1,35 @@
+package com.ericsson.eiffel.remrem.generate.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+
+@Profile("integration-test")
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig extends WebSecurityConfigurerAdapter {
+    @Override
+    protected void configure(AuthenticationManagerBuilder auth) throws Exception {
+        auth
+                .inMemoryAuthentication()
+                    .withUser("user")
+                    .password("secret")
+                    .roles("USER");
+    }
+
+    @Override
+    protected void configure(HttpSecurity http) throws Exception {
+        http
+                .authorizeRequests()
+                    .anyRequest()
+                    .authenticated()
+                    .and()
+                .httpBasic()
+                    .and()
+                .csrf()
+                    .disable();
+    }
+}

--- a/src/integration-test/java/com/ericsson/eiffel/remrem/generate/config/TestSecurityConfig.java
+++ b/src/integration-test/java/com/ericsson/eiffel/remrem/generate/config/TestSecurityConfig.java
@@ -10,7 +10,7 @@ import org.springframework.security.config.annotation.web.configuration.WebSecur
 @Profile("integration-test")
 @Configuration
 @EnableWebSecurity
-public class SecurityConfig extends WebSecurityConfigurerAdapter {
+public class TestSecurityConfig extends WebSecurityConfigurerAdapter {
     @Override
     protected void configure(AuthenticationManagerBuilder auth) throws Exception {
         auth

--- a/src/integration-test/resources/application.yml
+++ b/src/integration-test/resources/application.yml
@@ -3,4 +3,8 @@ spring:
     converters:
       preferred-json-mapper: gson
 jar:
-  path: 
+  path:
+activedirectory:
+  enabled: true
+  domain:
+  url:

--- a/src/main/java/com/ericsson/eiffel/remrem/generate/config/SecurityConfig.java
+++ b/src/main/java/com/ericsson/eiffel/remrem/generate/config/SecurityConfig.java
@@ -1,0 +1,40 @@
+package com.ericsson.eiffel.remrem.generate.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+import org.springframework.security.ldap.authentication.ad.ActiveDirectoryLdapAuthenticationProvider;
+
+// TODO Uncomment to enable AD backed security
+//@Profile("!integration-test")
+//@Configuration
+//@EnableWebSecurity
+public class SecurityConfig extends WebSecurityConfigurerAdapter {
+    @Value("${activedirectory.domain")
+    private String domain;
+
+    @Value("${activedirectory.url}")
+    private String url;
+
+    @Override
+    protected void configure(AuthenticationManagerBuilder auth) throws Exception {
+        ActiveDirectoryLdapAuthenticationProvider activeDirectoryLdapAuthenticationProvider = new
+                ActiveDirectoryLdapAuthenticationProvider(domain, url);
+
+        auth.authenticationProvider(activeDirectoryLdapAuthenticationProvider);
+    }
+
+    @Override
+    protected void configure(HttpSecurity http) throws Exception {
+        http
+                .authorizeRequests()
+                    .anyRequest()
+                    .authenticated()
+                    .and()
+                .httpBasic()
+                    .and()
+                .csrf()
+                    .disable();
+    }
+}

--- a/src/main/java/com/ericsson/eiffel/remrem/generate/config/SecurityConfig.java
+++ b/src/main/java/com/ericsson/eiffel/remrem/generate/config/SecurityConfig.java
@@ -1,15 +1,19 @@
 package com.ericsson.eiffel.remrem.generate.config;
 
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
 import org.springframework.security.ldap.authentication.ad.ActiveDirectoryLdapAuthenticationProvider;
 
-// TODO Uncomment to enable AD backed security
-//@Profile("!integration-test")
-//@Configuration
-//@EnableWebSecurity
+@Profile("!integration-test")
+@ConditionalOnProperty(prefix = "activedirectory.", value = "enabled")
+@Configuration
+@EnableWebSecurity
 public class SecurityConfig extends WebSecurityConfigurerAdapter {
     @Value("${activedirectory.domain")
     private String domain;

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -5,10 +5,10 @@ spring:
 debug: false
 logging:
   level:
-    root: INFO
+    root: ERROR
     org:
       springframework:
-        web: INFO
+        web: ERROR
 org:
   springframework:
     boot:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -16,7 +16,7 @@ org:
         LoggingSystem: none
 jar:
   path:
-# TODO Actual values for domain and url need to be provided
 activedirectory:
-  domain: "ERICSSON.COM"
-  url: "ldap://<hostname>.ericsson.com"
+  enabled: false
+  domain:
+  url:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -5,14 +5,18 @@ spring:
 debug: false
 logging:
   level:
-    root: ERROR
+    root: INFO
     org:
       springframework:
-        web: ERROR
+        web: INFO
 org:
   springframework:
     boot:
       logging:
         LoggingSystem: none
 jar:
-  path: 
+  path:
+# TODO Actual values for domain and url need to be provided
+activedirectory:
+  domain: "ERICSSON.COM"
+  url: "ldap://<hostname>.ericsson.com"


### PR DESCRIPTION
Adds support and configuration for authenticating against an Active Directory server but does not enable it.
HTTP Basic authentication is applied to all REST endpoints. It means a request must contain an Authorization header with <username:password> base64 encoded. Using curl it's enough to add the option -u <username:password>.