### PR TITLE
Updated remrem-shared version to 0.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.8.0
+- Updated remrem-shared version to 0.3.2 to support base64 encryption functionality for Ldap manager password.
+
 ## 0.7.9
 - Moved ldap related functionality to shared
 

--- a/build.gradle
+++ b/build.gradle
@@ -38,7 +38,7 @@ subprojects {
 	targetCompatibility = 1.8
 	
 	//Latest version for generate
-	version = "0.7.9"
+	version = "0.8.0"
 	
 	repositories {
         mavenCentral()
@@ -47,7 +47,7 @@ subprojects {
     
 	dependencies {
 	    //Injectable Message Library and its Implementation
-	    compile ('com.github.Ericsson:eiffel-remrem-shared:0.3.1')
+	    compile ('com.github.Ericsson:eiffel-remrem-shared:0.3.2')
 	    compile ('com.github.Ericsson:eiffel-remrem-semantics:0.2.3')
 	    compile ('com.github.Ericsson:eiffel-remrem-protocol-interface:0.0.1')
 	    
@@ -55,7 +55,6 @@ subprojects {
     	compile("org.springframework.boot:spring-boot-starter-security:$sprintBootVersion")
     	compile("org.springframework.security:spring-security-ldap:4.1.3.RELEASE")
     	compile("org.apache.directory.server:apacheds-server-jndi:1.5.5")
-    	
     	// Test framework
 	    testCompile 'junit:junit:4.12'
 	    testCompile 'org.assertj:assertj-core:3.4.1'

--- a/service/src/main/resources/config.properties
+++ b/service/src/main/resources/config.properties
@@ -17,6 +17,7 @@
 
   activedirectory.enabled:false
   activedirectory.ldapUrl : 
-  activedirectory.ldapPassword :
+  activedirectory.managerPassword :
   activedirectory.managerDn:
+  activedirectory.rootDn :
   activedirectory.userSearchFilter:


### PR DESCRIPTION
Implemented base64 encryption functionality for ldap manager password in remrem-shared

- added rootDn property in ldap configurations

- variable name changed from ldapPassword to managerPassword