### PR TITLE
Uplifted remrem-semantics version to 0.2.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.8.8
+- Uplifted remrem-semantics version to 0.2.9 to accept case insensitive eventType through query params.
+
 ## 0.8.7
 - Added validation that can detect duplicate keys in the JSON request body
 

--- a/build.gradle
+++ b/build.gradle
@@ -53,7 +53,7 @@ subprojects {
 	targetCompatibility = 1.8
 	
 	//Latest version for generate
-	version = "0.8.7"
+	version = "0.8.8"
 	
 	repositories {
         mavenCentral()
@@ -64,7 +64,7 @@ subprojects {
     dependencies {
         //Injectable Message Library and its Implementation
         compile ('com.github.Ericsson:eiffel-remrem-shared:0.3.4')
-        compile ('com.github.Ericsson:eiffel-remrem-semantics:0.2.8')
+        compile ('com.github.Ericsson:eiffel-remrem-semantics:0.2.9')
         compile ('com.github.Ericsson:eiffel-remrem-protocol-interface:0.0.1')
 
         //Authentication


### PR DESCRIPTION
Uplifted remrem-semantics version to 0.2.9 to accept case insensitive eventType 