### PR TITLE
Restructured REMReM Generate documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+.gradle/
+.idea/
+gradle/
+gradlew
+gradlew.bat

--- a/cliUsage.html
+++ b/cliUsage.html
@@ -206,52 +206,6 @@ usage: java -jar
    }
 ]       </pre>
 
-        <h2>
-            <a id="status-codes" class="anchor" href="#status-codes" aria-hidden="true">
-                <span aria-hidden="true" class="octicon octicon-link"></span>
-            </a>Status Codes
-        </h2>
-        <p>The response generated will have internal status codes for each and every event based on the input JSON provided.</p>
-        <p>Status codes are generated according to the below table.</p>
-        <table class="wikitable">
-            <tr>
-                <th style="text-align: left;">Status code</th>
-                <th style="text-align: left;">Result</th>
-                <th style="text-align: left;">Message</th>
-                <th style="text-align: left;">Comment</th>
-            </tr>
-            <tr>
-                <td>200</td>
-                <td>OK</td>
-                <td></td>
-                <td>Event generated successfully</td>
-            </tr>
-            <tr>
-                <td>400</td>
-                <td>Bad Request</td>
-                <td>Could not read document: Unrecognized token</td>
-                <td>Malformed JSON (missing braces or wrong event type, etc..), client need to fix problem in event before submitting again</td>
-            </tr>
-            <tr>
-                <td>404</td>
-                <td>Not Found</td>
-                <td>Requested template is not available</td>
-                <td>The endpoint is not found, or template for specified event type is not found</td>
-            </tr>
-            <tr>
-                <td>500</td>
-                <td>Internal Server Error</td>
-                <td>Internal server error</td>
-                <td>When REMReM Generate is down, possible to try again later when server is up</td>
-            </tr>
-            <tr>
-                <td>503</td>
-                <td>Service Unavailable</td>
-                <td>"No protocol service has been found registered"</td>
-                <td>When specified message protocol is not loaded</td>
-            </tr>
-        </table>
-
     </section>
 </div>
 

--- a/cliUsage.html
+++ b/cliUsage.html
@@ -47,17 +47,24 @@
 
 
         <pre>java -jar generate-cli.jar -h
+
 You passed help flag.
 usage: java -jar
+
  -d,--debug                  enable debug traces
+
  -f,--content_file           message content file
- -h,--help                   show help.
+
+ -h,--help                   show help
+
  -json,--json_content        JSON content
- -mp,--messaging_protocol    name of messaging protocol to be used,
-                             e.g. eiffel3, eiffelsemantics
+
+ -mp,--messaging_protocol    name of messaging protocol to be used, e.g. eiffel3, eiffelsemantics
+
  -r,--response_file          file to store the response in, optional
- -t,--message_type           message type, mandatory if -f or -json
-                             is given
+
+ -t,--message_type           message type, mandatory if -f or -json is given
+
  -v,--list_versions          lists the versions of generate and all loaded protocols
         </pre>
 
@@ -120,17 +127,30 @@ usage: java -jar
   }
 }       </pre>
 
-        <h3>
-            <a id="with-input-from-the-example-file-shown-above-and-output-to-a-file" class="anchor"
-               href="#with-input-from-the-example-file-shown-above-and-output-to-a-file" aria-hidden="true">
+        <h2>
+            <a id="examples" class="anchor" href="#examples" aria-hidden="true">
                 <span aria-hidden="true" class="octicon octicon-link"></span>
-            </a>With input from the example file shown above and output to a file:
-        </h3>
+            </a>Examples
+        </h2>
+        <p>Typical examples of usage Eiffel REMReM Generate CLI are described below.</p>
+
+        <h5>With input from the example file shown above and output to a file:</h5>
         <pre><code>$ java -jar generate-cli.jar -f eiffelactivityfinished.json -t eiffelactivityfinishedevent -r output.json</code></pre>
 
-        <p>Gives:</p>
-        <pre>$cat output.json
-[
+        <h5>Same example, but output the result on the console:</h5>
+        <pre><code>$ java -jar generate-cli.jar -f eiffelactivityfinished.json -t eiffelactivityfinished</code></pre>
+
+        <h5>Same example, but this time the data is supplied as a command line argument:</h5>
+        <pre><code style="font-size: 11px">$ java -jar generate-cli.jar -t eiffelactivityfinished -json {\"msgParams\":{\"meta\":{\"type\":\"EiffelActivityFinishedEvent\",\"tags\":[\"tag1\",\"tag2\"],\"source\":{\"domainId\":\"example.domain\",\"host\":\"host\",\"name\":\"name\",\"uri\":\"http://java.sun.com/j2se/1.3/\",\"gav\":{\"groupId\":\"com.github.Ericsson\",\"artifactId\":\"eiffel-remrem-semantics\",\"version\":\"0.4.0\"}},\"security\":{\"sdm\":{\"authorIdentity\":\"test\",\"encryptedDigest\":\"sample\"}}}},\"eventParams\":{\"data\":{\"outcome\":{\"conclusion\":\"SUCCESSFUL\"},\"persistentLogs\":[{\"name\":\"firstLog\",\"uri\":\"http://myHost.com/firstLog\"},{\"name\":\"otherLog\",\"uri\":\"isbn:0-486-27557-4\"}]},\"links\":[{\"type\":\"ACTIVITY_EXECUTION\",\"target\":\"aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee1\"}]}}</code></pre>
+
+        <h5>For loading protocol jars other than <em>eiffelsemantics</em>:</h5>
+        <pre><code>$ java -Djava.ext.dirs="/path/to/jars/" -jar generate-cli.jar -f eiffeljobfinished.json -t eiffeljobfinished -mp protocoltype</code></pre>
+
+        <p><strong>NOTE:</strong> in the above example, protocol jar file must be present inside "/path/to/jars/" folder.</p>
+
+        <p>Typical output for these examples is:</p>
+
+        <pre>[
    {
       "meta":{
          "id":"534c0b84-9348-422b-8bee-c4023488cd5d",
@@ -186,32 +206,51 @@ usage: java -jar
    }
 ]       </pre>
 
-        <h3>
-            <a id="same-example-but-output-the-result-on-the-console" class="anchor"
-               href="#same-example-but-output-the-result-on-the-console" aria-hidden="true">
+        <h2>
+            <a id="status-codes" class="anchor" href="#status-codes" aria-hidden="true">
                 <span aria-hidden="true" class="octicon octicon-link"></span>
-            </a>Same example, but output the result on the console:
-        </h3>
-        <pre><code>$ java -jar generate-cli.jar -f eiffelactivityfinished.json -t eiffelactivityfinished</code></pre>
-
-        <p>Gives:</p>
-        <pre style="font-size: 11px">[{<br>"meta":{<br>"id":"534c0b84-9348-422b-8bee-c4023488cd5d",<br>"type":"EiffelActivityFinishedEvent",<br>"version":"1.1.0",<br>"time":1521534547653,<br>"tags":["tag1","tag2"],<br>"source":{"domainId":"example.domain","host":"host","name":"name",<br>"serializer":{"groupId":"com.github.Ericsson","artifactId":"eiffel-remrem-semantics","version":"0.4.0"},<br>"uri":"http://java.sun.com/j2se/1.3/"},<br>"security":{"sdm":{"authorIdentity":"test","encryptedDigest":"sample"}}<br>},<br>"data":{<br>"outcome":{"conclusion":"SUCCESSFUL"},<br>"persistentLogs":[{"name":"firstLog","uri":"http://myHost.com/firstLog"},{"name":"otherLog","uri":"isbn:0-486-27557-4"}],<br>"customData":[]<br>},<br>"links":[{"type":"ACTIVITY_EXECUTION","target":"aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee1"}]<br>}]</pre>
-
-        <h3>
-            <a id="same-example-but-this-time-the-data-is-supplied-as-a-command-line-argument" class="anchor"
-               href="#same-example-but-this-time-the-data-is-supplied-as-a-command-line-argument" aria-hidden="true">
-                <span aria-hidden="true" class="octicon octicon-link"></span>
-            </a>Same example, but this time the data is supplied as a command line argument:
-        </h3>
-        <pre><code style="font-size: 11px">$ java -jar generate-cli.jar -t eiffelactivityfinished -json {\"msgParams\":{\"meta\":{\"type\":\"EiffelActivityFinishedEvent\",\"tags\":[\"tag1\",\"tag2\"],\"source\":{\"domainId\":\"example.domain\",\"host\":\"host\",\"name\":\"name\",\"uri\":\"http://java.sun.com/j2se/1.3/\",\"gav\":{\"groupId\":\"com.github.Ericsson\",\"artifactId\":\"eiffel-remrem-semantics\",\"version\":\"0.4.0\"}},\"security\":{\"sdm\":{\"authorIdentity\":\"test\",\"encryptedDigest\":\"sample\"}}}},\"eventParams\":{\"data\":{\"outcome\":{\"conclusion\":\"SUCCESSFUL\"},\"persistentLogs\":[{\"name\":\"firstLog\",\"uri\":\"http://myHost.com/firstLog\"},{\"name\":\"otherLog\",\"uri\":\"isbn:0-486-27557-4\"}]},\"links\":[{\"type\":\"ACTIVITY_EXECUTION\",\"target\":\"aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee1\"}]}}</code></pre>
-
-        <p>Gives:</p>
-        <pre style="font-size: 11px">[{<br>"meta":{<br>"id":"534c0b84-9348-422b-8bee-c4023488cd5d",<br>"type":"EiffelActivityFinishedEvent",<br>"version":"1.1.0",<br>"time":1513758440588,<br>"tags":["tag1","tag2"],<br>"source":{"domainId":"example.domain","host":"host","name":"name","serializer":{"groupId":"com.github.Ericsson","artifactId":"eiffel-remrem-semantics","version":"0.4.0"},<br>"uri":"http://java.sun.com/j2se/1.3/"},<br>"security":{"sdm":{"authorIdentity":"test","encryptedDigest":"sample"}}<br>},<br>"data":{<br>"outcome":{"conclusion":"SUCCESSFUL"},<br>"persistentLogs":[{"name":"firstLog","uri":"http://myHost.com/firstLog"},{"name":"otherLog","uri":"isbn:0-486-27557-4"}],<br>"customData":[]<br>},<br>"links":[{"type":"ACTIVITY_EXECUTION","target":"aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee1"}]<br>}]</pre>
-
-        <p><strong>For loading protocol jars other than eiffel-remrem-semantics:</strong></p>
-        <pre><code>$ java -Djava.ext.dirs="/path/to/jars/" -jar generate-cli.jar -f eiffeljobfinished.json -t eiffeljobfinished -mp protocoltype</code></pre>
-
-        <p><strong>NOTE:</strong> in the above example, protocol jar file must be present inside "/path/to/jars/" folder.</p>
+            </a>Status Codes
+        </h2>
+        <p>The response generated will have internal status codes for each and every event based on the input JSON provided.</p>
+        <p>Status codes are generated according to the below table.</p>
+        <table class="wikitable">
+            <tr>
+                <th style="text-align: left;">Status code</th>
+                <th style="text-align: left;">Result</th>
+                <th style="text-align: left;">Message</th>
+                <th style="text-align: left;">Comment</th>
+            </tr>
+            <tr>
+                <td>200</td>
+                <td>OK</td>
+                <td></td>
+                <td>Event generated successfully</td>
+            </tr>
+            <tr>
+                <td>400</td>
+                <td>Bad Request</td>
+                <td>Could not read document: Unrecognized token</td>
+                <td>Malformed JSON (missing braces or wrong event type, etc..), client need to fix problem in event before submitting again</td>
+            </tr>
+            <tr>
+                <td>404</td>
+                <td>Not Found</td>
+                <td>Requested template is not available</td>
+                <td>The endpoint is not found, or template for specified event type is not found</td>
+            </tr>
+            <tr>
+                <td>500</td>
+                <td>Internal Server Error</td>
+                <td>Internal server error</td>
+                <td>When REMReM Generate is down, possible to try again later when server is up</td>
+            </tr>
+            <tr>
+                <td>503</td>
+                <td>Service Unavailable</td>
+                <td>"No protocol service has been found registered"</td>
+                <td>When specified message protocol is not loaded</td>
+            </tr>
+        </table>
 
     </section>
 </div>

--- a/cliUsage.html
+++ b/cliUsage.html
@@ -1,0 +1,228 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <meta charset='utf-8'>
+    <meta http-equiv="X-UA-Compatible" content="chrome=1">
+    <meta name="description" content="Eiffel-remrem-generate : eiffel-remrem-generate">
+
+    <link rel="stylesheet" type="text/css" media="screen" href="stylesheets/stylesheet.css">
+
+    <title>Eiffel REMReM Generate</title>
+</head>
+
+<body>
+
+<!-- HEADER -->
+<div id="header_wrap" class="outer">
+    <header class="inner">
+        <a id="forkme_banner" href="https://github.com/Ericsson/eiffel-remrem-generate">View on GitHub</a>
+
+        <h1><a class="project_title" href="index.html#project_title">Eiffel REMReM Generate</a></h1>
+
+        <section id="downloads">
+            <a class="zip_download_link" href="https://github.com/Ericsson/eiffel-remrem-generate/zipball/master">Download this project as a .zip
+                file</a>
+            <a class="tar_download_link" href="https://github.com/Ericsson/eiffel-remrem-generate/tarball/master">Download this project as a tar.gz
+                file</a>
+        </section>
+    </header>
+</div>
+<!-- MAIN CONTENT -->
+<div id="main_content_wrap" class="outer">
+    <section id="main_content" class="inner">
+        <h1>
+            <a id="remrem-generate-cli" class="anchor" href="#remrem-generate-cli" aria-hidden="true">
+                <span aria-hidden="true" class="octicon octicon-link"></span>
+            </a>REMReM Generate CLI
+        </h1>
+
+        <h2>
+            <a id="usage" class="anchor" href="#usage" aria-hidden="true">
+                <span aria-hidden="true" class="octicon octicon-link"></span>
+            </a>Usage
+        </h2>
+        <p>For using Eiffel REMReM Generate CLI self executing <strong>generate-cli.jar</strong> file should be executed in command line with parameters
+            described below.</p>
+
+
+        <pre>java -jar generate-cli.jar -h
+You passed help flag.
+usage: java -jar
+ -d,--debug                  enable debug traces
+ -f,--content_file           message content file
+ -h,--help                   show help.
+ -json,--json_content        JSON content
+ -mp,--messaging_protocol    name of messaging protocol to be used,
+                             e.g. eiffel3, eiffelsemantics
+ -r,--response_file          file to store the response in, optional
+ -t,--message_type           message type, mandatory if -f or -json
+                             is given
+ -v,--list_versions          lists the versions of generate and all loaded protocols
+        </pre>
+
+        <p><strong>Generate templates for Eiffel REMReM Semantics to be used are available
+            <a href="http://ericsson.github.io/eiffel-remrem-semantics/">here.</a></strong>
+        </p>
+
+        <p>The message must exist in a JSON file, for example <strong><em>eiffelactivityfinished.json</em></strong> might contain the following
+            message:</p>
+
+        <pre>
+{
+  "msgParams": {
+    "meta": {
+    "type": "EiffelActivityFinishedEvent",
+      "tags": [
+        "tag1",
+        "tag2"
+      ],
+      "source": {
+        "domainId": "example.domain",
+        "host": "host",
+        "name": "name",
+        "uri": "http://java.sun.com/j2se/1.3/",
+        "gav": {
+          "groupId": "com.github.Ericsson",
+          "artifactId": "eiffel-remrem-semantics",
+          "version": "0.2.9"
+        }
+      },
+      "security": {
+        "sdm": {
+          "authorIdentity": "test",
+          "encryptedDigest": "sample"
+        }
+      }
+    }
+  },
+  "eventParams": {
+    "data": {
+      "outcome": {
+        "conclusion": "SUCCESSFUL"
+      },
+      "persistentLogs": [{
+          "name": "firstLog",
+          "uri": "http://myHost.com/firstLog"
+        },
+        {
+          "name": "otherLog",
+          "uri": "isbn:0-486-27557-4"
+        }
+      ]
+    },
+    "links": [
+        {
+            "type": "ACTIVITY_EXECUTION",
+            "target": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee1"
+        }
+    ]
+  }
+}       </pre>
+
+        <h3>
+            <a id="with-input-from-the-example-file-shown-above-and-output-to-a-file" class="anchor"
+               href="#with-input-from-the-example-file-shown-above-and-output-to-a-file" aria-hidden="true">
+                <span aria-hidden="true" class="octicon octicon-link"></span>
+            </a>With input from the example file shown above and output to a file:
+        </h3>
+        <pre><code>$ java -jar generate-cli.jar -f eiffelactivityfinished.json -t eiffelactivityfinishedevent -r output.json</code></pre>
+
+        <p>Gives:</p>
+        <pre>$cat output.json
+[
+   {
+      "meta":{
+         "id":"534c0b84-9348-422b-8bee-c4023488cd5d",
+         "type":"EiffelActivityFinishedEvent",
+         "version":"1.1.0",
+         "time":1521534547653,
+         "tags":[
+            "tag1",
+            "tag2"
+         ],
+         "source":{
+            "domainId":"example.domain",
+            "host":"host",
+            "name":"name",
+            "serializer":{
+               "groupId":"com.github.Ericsson",
+               "artifactId":"eiffel-remrem-semantics",
+               "version":"0.4.0"
+            },
+            "uri":"http://java.sun.com/j2se/1.3/"
+         },
+         "security":{
+            "sdm":{
+               "authorIdentity":"test",
+               "encryptedDigest":"sample"
+            }
+         }
+      },
+      "data":{
+         "outcome":{
+            "conclusion":"SUCCESSFUL"
+         },
+         "persistentLogs":[
+            {
+               "name":"firstLog",
+               "uri":"http://myHost.com/firstLog"
+            },
+            {
+               "name":"otherLog",
+               "uri":"isbn:0-486-27557-4"
+            }
+         ],
+         "customData":[
+
+         ]
+      },
+      "links":[
+         {
+            "type":"ACTIVITY_EXECUTION",
+            "target":"aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee1"
+         }
+      ]
+   }
+]       </pre>
+
+        <h3>
+            <a id="same-example-but-output-the-result-on-the-console" class="anchor"
+               href="#same-example-but-output-the-result-on-the-console" aria-hidden="true">
+                <span aria-hidden="true" class="octicon octicon-link"></span>
+            </a>Same example, but output the result on the console:
+        </h3>
+        <pre><code>$ java -jar generate-cli.jar -f eiffelactivityfinished.json -t eiffelactivityfinished</code></pre>
+
+        <p>Gives:</p>
+        <pre style="font-size: 11px">[{<br>"meta":{<br>"id":"534c0b84-9348-422b-8bee-c4023488cd5d",<br>"type":"EiffelActivityFinishedEvent",<br>"version":"1.1.0",<br>"time":1521534547653,<br>"tags":["tag1","tag2"],<br>"source":{"domainId":"example.domain","host":"host","name":"name",<br>"serializer":{"groupId":"com.github.Ericsson","artifactId":"eiffel-remrem-semantics","version":"0.4.0"},<br>"uri":"http://java.sun.com/j2se/1.3/"},<br>"security":{"sdm":{"authorIdentity":"test","encryptedDigest":"sample"}}<br>},<br>"data":{<br>"outcome":{"conclusion":"SUCCESSFUL"},<br>"persistentLogs":[{"name":"firstLog","uri":"http://myHost.com/firstLog"},{"name":"otherLog","uri":"isbn:0-486-27557-4"}],<br>"customData":[]<br>},<br>"links":[{"type":"ACTIVITY_EXECUTION","target":"aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee1"}]<br>}]</pre>
+
+        <h3>
+            <a id="same-example-but-this-time-the-data-is-supplied-as-a-command-line-argument" class="anchor"
+               href="#same-example-but-this-time-the-data-is-supplied-as-a-command-line-argument" aria-hidden="true">
+                <span aria-hidden="true" class="octicon octicon-link"></span>
+            </a>Same example, but this time the data is supplied as a command line argument:
+        </h3>
+        <pre><code style="font-size: 11px">$ java -jar generate-cli.jar -t eiffelactivityfinished -json {\"msgParams\":{\"meta\":{\"type\":\"EiffelActivityFinishedEvent\",\"tags\":[\"tag1\",\"tag2\"],\"source\":{\"domainId\":\"example.domain\",\"host\":\"host\",\"name\":\"name\",\"uri\":\"http://java.sun.com/j2se/1.3/\",\"gav\":{\"groupId\":\"com.github.Ericsson\",\"artifactId\":\"eiffel-remrem-semantics\",\"version\":\"0.4.0\"}},\"security\":{\"sdm\":{\"authorIdentity\":\"test\",\"encryptedDigest\":\"sample\"}}}},\"eventParams\":{\"data\":{\"outcome\":{\"conclusion\":\"SUCCESSFUL\"},\"persistentLogs\":[{\"name\":\"firstLog\",\"uri\":\"http://myHost.com/firstLog\"},{\"name\":\"otherLog\",\"uri\":\"isbn:0-486-27557-4\"}]},\"links\":[{\"type\":\"ACTIVITY_EXECUTION\",\"target\":\"aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee1\"}]}}</code></pre>
+
+        <p>Gives:</p>
+        <pre style="font-size: 11px">[{<br>"meta":{<br>"id":"534c0b84-9348-422b-8bee-c4023488cd5d",<br>"type":"EiffelActivityFinishedEvent",<br>"version":"1.1.0",<br>"time":1513758440588,<br>"tags":["tag1","tag2"],<br>"source":{"domainId":"example.domain","host":"host","name":"name","serializer":{"groupId":"com.github.Ericsson","artifactId":"eiffel-remrem-semantics","version":"0.4.0"},<br>"uri":"http://java.sun.com/j2se/1.3/"},<br>"security":{"sdm":{"authorIdentity":"test","encryptedDigest":"sample"}}<br>},<br>"data":{<br>"outcome":{"conclusion":"SUCCESSFUL"},<br>"persistentLogs":[{"name":"firstLog","uri":"http://myHost.com/firstLog"},{"name":"otherLog","uri":"isbn:0-486-27557-4"}],<br>"customData":[]<br>},<br>"links":[{"type":"ACTIVITY_EXECUTION","target":"aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee1"}]<br>}]</pre>
+
+        <p><strong>For loading protocol jars other than eiffel-remrem-semantics:</strong></p>
+        <pre><code>$ java -Djava.ext.dirs="/path/to/jars/" -jar generate-cli.jar -f eiffeljobfinished.json -t eiffeljobfinished -mp protocoltype</code></pre>
+
+        <p><strong>NOTE:</strong> in the above example, protocol jar file must be present inside "/path/to/jars/" folder.</p>
+
+    </section>
+</div>
+
+<!-- FOOTER  -->
+<div id="footer_wrap" class="outer">
+    <footer class="inner">
+        <p class="copyright">Eiffel REMReM Generate maintained by <a href="https://github.com/ericsson">Ericsson</a></p>
+        <p>Published with <a href="https://pages.github.com">GitHub Pages</a></p>
+    </footer>
+</div>
+
+</body>
+</html>

--- a/cliUsage.html
+++ b/cliUsage.html
@@ -59,7 +59,7 @@ usage: java -jar
 
  -json,--json_content        JSON content
 
- -mp,--messaging_protocol    name of messaging protocol to be used, e.g. eiffel3, eiffelsemantics
+ -mp,--messaging_protocol    name of messaging protocol to be used, e.g. eiffelsemantics
 
  -r,--response_file          file to store the response in, optional
 
@@ -147,6 +147,10 @@ usage: java -jar
         <pre><code>$ java -Djava.ext.dirs="/path/to/jars/" -jar generate-cli.jar -f eiffeljobfinished.json -t eiffeljobfinished -mp protocoltype</code></pre>
 
         <p><strong>NOTE:</strong> in the above example, protocol jar file must be present inside "/path/to/jars/" folder.</p>
+        <p><strong>NOTE:</strong> <code>-Djava.ext.dirs</code> is no longer working in some JAVA8 versions and in JAVA9.
+            So users should create a wrapper project to include both Generate/Publish and their protocol in
+            or place the protocol library in the folder for external dependencies of their JVM installation.
+        </p>
 
         <p>Typical output for these examples is:</p>
 
@@ -205,6 +209,43 @@ usage: java -jar
       ]
    }
 ]       </pre>
+
+        <h2>
+            <a id="exit-codes" class="anchor" href="#exitCodes" aria-hidden="true">
+                <span aria-hidden="true" class="octicon octicon-link"></span>
+            </a>Exit Codes
+        </h2>
+        <p>If CLI fails internally before trying to generate Eiffel message, user will get exit code. Exit codes are described in the table below.</p>
+
+        <table class="wikitable">
+            <tr>
+                <th style="text-align: left;">Exit code</th>
+                <th style="text-align: left;">Description</th>
+            <tr>
+                <td>1</td>
+                <td>User will get this exit code in case of some error that is not described below</td>
+            </tr>
+            <tr>
+                <td>2</td>
+                <td>Some CLI options are missed</td>
+            </tr>
+            <tr>
+                <td>3</td>
+                <td>Unable to read content from passed file path</td>
+            </tr>
+            <tr>
+                <td>4</td>
+                <td>Unable to read passed JSON string from command line</td>
+            </tr>
+            <tr>
+                <td>5</td>
+                <td>Unable to send JSON message to message service</td>
+            </tr>
+            <tr>
+                <td>6</td>
+                <td>Passed message protocol is not correct</td>
+            </tr>
+        </table>
 
     </section>
 </div>

--- a/index.html
+++ b/index.html
@@ -35,33 +35,14 @@
         <h2>Introduction</h2>
         <p>REMReM (<strong>REST Mailbox for Registered Messages</strong>) is a set of tools that can be used to generate validated Eiffel messages and
             publish them on a RabbitMQ message bus. They can be run as micro services or as stand-alone CLI versions. For more details on the micro
-            services and the REMReM design, see <a href="https://github.com/Ericsson/eiffel-remrem">https://github.com/Ericsson/eiffel-remrem</a>
+            services and the REMReM design, see <a href="https://github.com/Ericsson/eiffel-remrem">Eiffel REMReM</a>
         </p>
-        <p>Generate takes a partial message in JSON format, validates it and adds mandatory fields before outputting a complete, valid Eiffel
-            message.</p>
-        <h2>
-            <a id="installation" class="anchor" href="#installation" aria-hidden="true">
-                <span aria-hidden="true" class="octicon octicon-link"></span>
-            </a>Installation
-        </h2>
-        <p>You can use Eiffel REMReM Generate as a micro service or a java command line application.
-            This project is build by gradle, by executing following commands:</p>
-        <pre>./gradlew build</pre>
-        <p>The produced JAR file will be stored in eiffel-remrem-generate/cli/build/libs and
-            WAR will be in eiffel-remrem-generate/service/build/libs. Then you have 2 ways to execute it:
-            by running self executing JAR
-        <pre>java -jar generate-cli.jar</pre>
-        or deploy it in Tomcat (put it in tomcat/webapps/ folder and start the tomcat)
-        </p>
-        <p>Binary is released via <a href="https://jitpack.io/#Ericsson/eiffel-remrem-generate">jitPack</a></p>
-        <p><b>Download the latest version of CLI from </b><a onClick="getLatestVersion('cli','jar');" href="#">generate-cli.jar</a></p>
-        <p><b>Download the latest version of Service from </b><a onClick="getLatestVersion('service','war');" href="#">generate-service.war</a></p>
-        <div id="downloadLink" style="visibility: hidden;color: red;font-size: 14px;"></div>
-        <h2>Configuration</h2>
-        <p>This project does not need any configuration.</p>
+        <p>Eiffel REMReM Generate takes a partial message in JSON format, validates it and adds mandatory fields before outputting a complete,
+            valid Eiffel message.</p>
         <h2>
             <a id="compatibility" class="anchor" href="#compatibility" aria-hidden="true">
-                <span aria-hidden="true" class="octicon octicon-link"></span></a>Compatibility
+                <span aria-hidden="true" class="octicon octicon-link"></span>
+            </a>Compatibility
         </h2>
         <ul>
             <li>JDK 8</li>
@@ -70,13 +51,32 @@
         <p>For supporting latest features, Eiffel REMReM Publish should use the latest version of
             <a href="http://ericsson.github.io/eiffel-remrem-semantics/">Eiffel REMReM Semantics</a>.
         </p>
-
-        <p>Start the self executing JAR</p>
-        <pre>java -jar generate-cli.jar</pre>
-        <p>or deploy it in Tomcat.</p>
-
         <h2>
-            <a id="usage-cli-command-line-interface" class="anchor" href="#usage-cli-command-line-interface" aria-hidden="true">
+            <a id="components" class="anchor" href="#components" aria-hidden="true">
+                <span aria-hidden="true" class="octicon octicon-link"></span>
+            </a>Components
+        </h2>
+        <ul>
+            <li>REMReM Generate CLI (Command Line Interface)</li>
+            <li>REMReM Generate Service</li>
+        </ul>
+        <h2>
+            <a id="installation" class="anchor" href="#installation" aria-hidden="true">
+                <span aria-hidden="true" class="octicon octicon-link"></span>
+            </a>Installation
+        </h2>
+        <p>Eiffel REMReM Publish is gradle project and can be built by executing following command:</p>
+        <pre>./gradlew build</pre>
+        <p>Binary is released via <a href="https://jitpack.io/#Ericsson/eiffel-remrem-generate">jitPack</a>.</p>
+        <p>The latest REMReM Publish CLI binary can be downloaded via
+            <a onClick="getLatestVersion('cli','jar');" href="#installation">generate-cli.jar</a>.
+        </p>
+        <p>The latest REMReM Publish Service binary can be downloaded via
+            <a onClick="getLatestVersion('service','war');" href="#installation">generate-service.war</a>.
+        </p>
+        <div id="downloadLink" style="visibility: hidden;color: red;font-size: 14px;"></div>
+        <h2>
+            <a id="usage" class="anchor" href="#usage" aria-hidden="true">
                 <span aria-hidden="true" class="octicon octicon-link"></span>
             </a>Usage
         </h2>
@@ -86,26 +86,23 @@
         <p>To get information about configuration and usage of <strong>REMReM Generate Service</strong> see
             <a href="serviceUsage.html">here</a>.
         </p>
-
-
-        <p>Examples used here are for the next generation of Eiffel events called semantics which is open source. Please follow
+        <p>Examples used here are for the next generation of Eiffel events called semantics, which is open source. Please follow
             <a href="https://github.com/Ericsson/eiffel/tree/master/eiffel-syntax-and-usage">eiffel syntax</a> and
             <a href="https://github.com/Ericsson/eiffel/tree/master/eiffel-vocabulary">eiffel vocabulary</a>.
         </p>
-
-        <h2>Logging</h2>
-
+        <h2>
+            <a id="logging" class="anchor" href="#logging" aria-hidden="true">
+                <span aria-hidden="true" class="octicon octicon-link"></span>
+            </a>Logging
+        </h2>
         <p>REMReM Generate application logging is implemented using the logback-classic. It requires user to configure the logback.xml file.<br>
             When used without logback.xml log messages will look as below:
         </p>
-
         <pre><code>%PARSER_ERROR[wEx]%PARSER_ERROR[clr] %PARSER_ERROR[clr] %PARSER_ERROR[clr] %PARSER_ERROR[clr]
             <br>%PARSER_ERROR[clr] %PARSER_ERROR[clr] %PARSER_ERROR[clr]</code></pre>
-
         <p>To configure the logback.xml file use <strong>-Dlogging.config=path/logback.xml</strong></p>
-        <p><a href="https://logback.qos.ch/manual/configuration.html">Click here</a> for info about logback configurations</p>
-        <p>To get sample logback.xml to use <a target="_blank" href="logback/logback-sample.xml">Click Here</a></p>
-
+        <p>To get info about logback configurations see <a href="https://logback.qos.ch/manual/configuration.html">here</a>.</p>
+        <p>To get sample logback.xml to use see <a target="_blank" href="logback/logback-sample.xml">here</a>.</p>
     </section>
 </div>
 

--- a/index.html
+++ b/index.html
@@ -5,8 +5,8 @@
     <meta charset='utf-8'>
     <meta http-equiv="X-UA-Compatible" content="chrome=1">
     <meta name="description" content="Eiffel-remrem-generate : eiffel-remrem-generate">
-
     <link rel="stylesheet" type="text/css" media="screen" href="stylesheets/stylesheet.css">
+    <script type="text/javascript" src="javascripts/download.js"></script>
 
     <title>Eiffel REMReM Generate</title>
 </head>
@@ -18,7 +18,7 @@
     <header class="inner">
         <a id="forkme_banner" href="https://github.com/Ericsson/eiffel-remrem-generate">View on GitHub</a>
 
-        <h1 id="project_title">Eiffel REMReM Generate</h1>
+        <h1><a class="project_title" href="index.html#project_title">Eiffel REMReM Generate</a></h1>
 
         <section id="downloads">
             <a class="zip_download_link" href="https://github.com/Ericsson/eiffel-remrem-generate/zipball/master">Download this project as a .zip
@@ -32,69 +32,44 @@
 <!-- MAIN CONTENT -->
 <div id="main_content_wrap" class="outer">
     <section id="main_content" class="inner">
+        <h2>Introduction</h2>
         <p>REMReM (<strong>REST Mailbox for Registered Messages</strong>) is a set of tools that can be used to generate validated Eiffel messages and
             publish them on a RabbitMQ message bus. They can be run as micro services or as stand-alone CLI versions. For more details on the micro
             services and the REMReM design, see <a href="https://github.com/Ericsson/eiffel-remrem">https://github.com/Ericsson/eiffel-remrem</a>
         </p>
-
-        <p>Generate takes a partial message in JSON format, validates it and adds mandatory fields before outputting a complete, valid Eiffel message.</p>
-
+        <p>Generate takes a partial message in JSON format, validates it and adds mandatory fields before outputting a complete, valid Eiffel
+            message.</p>
         <h2>
-            <a id="compatibility" class="anchor" href="#compatibility" aria-hidden="true">
-                <span aria-hidden="true" class="octicon octicon-link"></span></a>Compatibility
-        </h2>
-
-        <ul>
-            <li>JDK 8</li>
-            <li>Tomcat 8</li>
-        </ul>
-
-        <h2>
-            <a id="the-releases" class="anchor" href="#the-releases" aria-hidden="true">
+            <a id="installation" class="anchor" href="#installation" aria-hidden="true">
                 <span aria-hidden="true" class="octicon octicon-link"></span>
-            </a>The releases
+            </a>Installation
         </h2>
-
+        <p>You can use Eiffel REMReM Generate as a micro service or a java command line application.
+            This project is build by gradle, by executing following commands:</p>
+        <pre>./gradlew build</pre>
+        <p>The produced JAR file will be stored in eiffel-remrem-generate/cli/build/libs and
+            WAR will be in eiffel-remrem-generate/service/build/libs. Then you have 2 ways to execute it:
+            by running self executing JAR
+        <pre>java -jar generate-cli.jar</pre>
+        or deploy it in Tomcat (put it in tomcat/webapps/ folder and start the tomcat)
+        </p>
         <p>Binary is released via <a href="https://jitpack.io/#Ericsson/eiffel-remrem-generate">jitPack</a></p>
         <p><b>Download the latest version of CLI from </b><a onClick="getLatestVersion('cli','jar');" href="#">generate-cli.jar</a></p>
         <p><b>Download the latest version of Service from </b><a onClick="getLatestVersion('service','war');" href="#">generate-service.war</a></p>
         <div id="downloadLink" style="visibility: hidden;color: red;font-size: 14px;"></div>
-        <script type="text/javascript">
-            function getLatestVersion(type,extn){
-                var xhr = new XMLHttpRequest();
-                xhr.open("GET", "https://jitpack.io/v/Ericsson/eiffel-remrem-generate.svg");
-                xhr.responseType = "blob";//force the HTTP response, response-type header to be blob
-                xhr.onload = function()
-                {
-                    var blob = xhr.response;
-                    var reader = new FileReader();
-                    reader.addEventListener("loadend", function() {
-                        var result = reader.result;
-                        if(result=="Repo not found or no access token provided"){
-                            document.getElementById("downloadLink").innerHTML = result;
-                            document.getElementById("downloadLink").style.visibility = "";
-                        }
-                        else{
-                            document.getElementById("downloadLink").innerHTML = result;
-                            var val = document.getElementsByTagName("text")[2].innerHTML;
-                            val = val.trim();
-                            urlLink = "https://jitpack.io/com/github/Ericsson/eiffel-remrem-generate/generate-"+type +"/"+val+"/generate-"+type +"-"+val+"."+extn;
-                            var link = document.createElement("a");
-                            link.href = urlLink;
-                            link.click();
-                        }
-                    });
-                    reader.readAsBinaryString(blob);
-                }
-                xhr.send();
-            }
-        </script>
-
+        <h2>Configuration</h2>
+        <p>This project does not need any configuration.</p>
         <h2>
-            <a id="installation" class="anchor" href="#installation" aria-hidden="true">
-                <span aria-hidden="true" class="octicon octicon-link"></span>
-            </a>Installation (Micro service)
+            <a id="compatibility" class="anchor" href="#compatibility" aria-hidden="true">
+                <span aria-hidden="true" class="octicon octicon-link"></span></a>Compatibility
         </h2>
+        <ul>
+            <li>JDK 8</li>
+            <li>Tomcat 8</li>
+        </ul>
+        <p>For supporting latest features, Eiffel REMReM Publish should use the latest version of
+            <a href="http://ericsson.github.io/eiffel-remrem-semantics/">Eiffel REMReM Semantics</a>.
+        </p>
 
         <p>Start the self executing JAR</p>
         <pre>java -jar generate-cli.jar</pre>
@@ -103,337 +78,20 @@
         <h2>
             <a id="usage-cli-command-line-interface" class="anchor" href="#usage-cli-command-line-interface" aria-hidden="true">
                 <span aria-hidden="true" class="octicon octicon-link"></span>
-            </a>Usage CLI (Command Line Interface)
+            </a>Usage
         </h2>
+        <p>To get information about configuration and usage of <strong>REMReM Generate CLI</strong> see
+            <a href="cliUsage.html">here</a>.
+        </p>
+        <p>To get information about configuration and usage of <strong>REMReM Generate Service</strong> see
+            <a href="serviceUsage.html">here</a>.
+        </p>
+
 
         <p>Examples used here are for the next generation of Eiffel events called semantics which is open source. Please follow
             <a href="https://github.com/Ericsson/eiffel/tree/master/eiffel-syntax-and-usage">eiffel syntax</a> and
             <a href="https://github.com/Ericsson/eiffel/tree/master/eiffel-vocabulary">eiffel vocabulary</a>.
         </p>
-
-        <pre>java -jar generate-cli.jar -h
-You passed help flag.
-usage: java -jar
- -d,--debug                  enable debug traces
- -f,--content_file           message content file
- -h,--help                   show help.
- -json,--json_content        JSON content
- -mp,--messaging_protocol    name of messaging protocol to be used,
-                             e.g. eiffel3, eiffelsemantics
- -r,--response_file          file to store the response in, optional
- -t,--message_type           message type, mandatory if -f or -json
-                             is given
- -v,--list_versions          lists the versions of generate and all loaded protocols
-        </pre>
-
-        <p><strong>Generate templates for eiffel-remrem-semantics to be used are available
-            <a href="http://ericsson.github.io/eiffel-remrem-semantics/">here.</a></strong>
-        </p>
-
-        <p>The message must exist in a JSON file, for example <strong><em>eiffelactivityfinished.json</em></strong> might contain the following message:</p>
-
-        <pre>
-{
-  "msgParams": {
-    "meta": {
-    "type": "EiffelActivityFinishedEvent",
-      "tags": [
-        "tag1",
-        "tag2"
-      ],
-      "source": {
-        "domainId": "example.domain",
-        "host": "host",
-        "name": "name",
-        "uri": "http://java.sun.com/j2se/1.3/",
-        "gav": {
-          "groupId": "com.github.Ericsson",
-          "artifactId": "eiffel-remrem-semantics",
-          "version": "0.2.9"
-        }
-      },
-      "security": {
-        "sdm": {
-          "authorIdentity": "test",
-          "encryptedDigest": "sample"
-        }
-      }
-    }
-  },
-  "eventParams": {
-    "data": {
-      "outcome": {
-        "conclusion": "SUCCESSFUL"
-      },
-      "persistentLogs": [{
-          "name": "firstLog",
-          "uri": "http://myHost.com/firstLog"
-        },
-        {
-          "name": "otherLog",
-          "uri": "isbn:0-486-27557-4"
-        }
-      ]
-    },
-    "links": [
-        {
-            "type": "ACTIVITY_EXECUTION",
-            "target": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee1"
-        }
-    ]
-  }
-}       </pre>
-
-        <h3>
-            <a id="with-input-from-the-example-file-shown-above-and-output-to-a-file" class="anchor"
-               href="#with-input-from-the-example-file-shown-above-and-output-to-a-file" aria-hidden="true">
-                <span aria-hidden="true" class="octicon octicon-link"></span>
-            </a>With input from the example file shown above and output to a file:
-        </h3>
-        <pre><code>$ java -jar generate-cli.jar -f eiffelactivityfinished.json -t eiffelactivityfinishedevent -r output.json</code></pre>
-
-        <p>Gives:</p>
-        <pre>$cat output.json
-[
-   {
-      "meta": {
-         "id": "7214aead-7702-44dd-915d-a8c0cd346eac",
-         "type": "EiffelActivityFinishedEvent",
-         "version": "1.0.0",
-         "time": 1508760894525,
-         "tags": [
-            "tag1",
-            "tag2"
-         ],
-         "source": {
-            "domainId": "example.domain",
-            "host": "host",
-            "name": "name",
-            "gav": {
-               "groupId": "com.github.Ericsson",
-               "artifactId": "eiffel-remrem-semantics",
-               "version": "0.2.9"
-            },
-            "uri": "http://java.sun.com/j2se/1.3/"
-         },
-         "security": {
-            "sdm": {
-               "authorIdentity": "test",
-               "encryptedDigest": "sample"
-            }
-         }
-      },
-      "data": {
-         "outcome": {
-            "conclusion": "SUCCESSFUL"
-         },
-         "persistentLogs": [
-            {
-               "name": "firstLog",
-               "uri": "http://myHost.com/firstLog"
-            },
-            {
-               "name": "otherLog",
-               "uri": "isbn:0-486-27557-4"
-            }
-         ],
-         "customData": []
-      },
-      "links": [
-         {
-            "type": "ACTIVITY_EXECUTION",
-            "target": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee1"
-         }
-      ]
-   }
-]       </pre>
-
-        <h3>
-            <a id="same-example-but-output-the-result-on-the-console" class="anchor"
-               href="#same-example-but-output-the-result-on-the-console" aria-hidden="true">
-                <span aria-hidden="true" class="octicon octicon-link"></span>
-            </a>Same example, but output the result on the console:
-        </h3>
-        <pre><code>$ java -jar generate-cli.jar -f eiffelactivityfinished.json -t eiffelactivityfinished</code></pre>
-
-        <p>Gives:</p>
-        <pre style="font-size: 11px">[{<br>"meta":{<br>"id":"963da060-f2cf-4370-a68d-67fd872def36",<br>"type":"EiffelActivityFinishedEvent",<br>"version":"1.0.0",<br>"time":1513758440588,<br>"tags":["tag1","tag2"],<br>"source":{"domainId":"example.domain","host":"host","name":"name",<br>"serializer":{"groupId":"com.github.Ericsson","artifactId":"eiffel-remrem-semantics","version":"0.3.1"},<br>"uri":"http://java.sun.com/j2se/1.3/"},<br>"security":{"sdm":{"authorIdentity":"test","encryptedDigest":"sample"}}<br>},<br>"data":{<br>"outcome":{"conclusion":"SUCCESSFUL"},<br>"persistentLogs":[{"name":"firstLog","uri":"http://myHost.com/firstLog"},{"name":"otherLog","uri":"isbn:0-486-27557-4"}],<br>"customData":[]<br>},<br>"links":[{"type":"ACTIVITY_EXECUTION","target":"aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee1"}]<br>}]</pre>
-
-        <h3>
-            <a id="same-example-but-this-time-the-data-is-supplied-as-a-command-line-argument" class="anchor"
-               href="#same-example-but-this-time-the-data-is-supplied-as-a-command-line-argument" aria-hidden="true">
-                <span aria-hidden="true" class="octicon octicon-link"></span>
-            </a>Same example, but this time the data is supplied as a command line argument:
-        </h3>
-        <pre><code style="font-size: 11px">$ java -jar generate-cli.jar -t eiffelactivityfinished -json '{"msgParams": {"meta": {"type":"EiffelActivityFinishedEvent","tags": ["tag1", "tag2"],"source": {"domainId": "example.domain","host": "host","name": "name","uri": "http://java.sun.com/j2se/1.3/","gav": {"groupId": "com.github.Ericsson","artifactId": "eiffel-remrem-semantics","version": "0.2.9"}}}},"eventParams": {"data": {"outcome": {"conclusion": "SUCCESSFUL"},"persistentLogs": [{"name": "firstLog","uri": "http://myHost.com/firstLog"},{"name": "otherLog","uri": "isbn:0-486-27557-4"}]},"links": [{"type": "ACTIVITY_EXECUTION","target": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee1"}]}}'</code></pre>
-
-        <p>Gives:</p>
-        <pre style="font-size: 11px">[{<br>"meta":{<br>"id":"963da060-f2cf-4370-a68d-67fd872def36",<br>"type":"EiffelActivityFinishedEvent",<br>"version":"1.0.0",<br>"time":1513758440588,<br>"tags":["tag1","tag2"],<br>"source":{"domainId":"example.domain","host":"host","name":"name","serializer":{"groupId":"com.github.Ericsson","artifactId":"eiffel-remrem-semantics","version":"0.3.1"},<br>"uri":"http://java.sun.com/j2se/1.3/"},<br>"security":{"sdm":{"authorIdentity":"test","encryptedDigest":"sample"}}<br>},<br>"data":{<br>"outcome":{"conclusion":"SUCCESSFUL"},<br>"persistentLogs":[{"name":"firstLog","uri":"http://myHost.com/firstLog"},{"name":"otherLog","uri":"isbn:0-486-27557-4"}],<br>"customData":[]<br>},<br>"links":[{"type":"ACTIVITY_EXECUTION","target":"aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee1"}]<br>}]</pre>
-
-        <p><strong>For loading protocol jars other than eiffel-remrem-semantics:</strong></p>
-        <pre><code>$ java -Djava.ext.dirs="/path/to/jars/" -jar generate-cli.jar -f eiffeljobfinished.json -t eiffeljobfinished -mp protocoltype</code></pre>
-
-        <p><strong>NOTE:</strong> in the above example, protocol jar file must be present inside "/path/to/jars/" folder.</p>
-
-        <h2>
-            <a id="usage-rest-service" class="anchor" href="#usage-rest-service" aria-hidden="true">
-                <span aria-hidden="true" class="octicon octicon-link"></span>
-            </a>Usage REST service
-        </h2>
-
-        <p>Deploy the generate-service.war in Tomcat.</p>
-
-        <p>Examples used here are for the next generation of Eiffel events called semantics which is open source. Please follow
-            <a href="https://github.com/Ericsson/eiffel/tree/master/eiffel-syntax-and-usage">eiffel syntax</a> and
-            <a href="https://github.com/Ericsson/eiffel/tree/master/eiffel-vocabulary">eiffel vocabulary</a>.
-        </p>
-
-        <p>We can get information about the REMReM Generate Service all endpoints and easily access them from here:<br>
-            <em>http://&lt;host&gt;:&lt;port&gt;/&lt;application name&gt;/</em> or <em>http://&lt;host&gt;:&lt;port&gt;/&lt;application name&gt;/swagger-ui.html</em>
-        </p>
-
-        <p>Available REST resources for generate are:</p>
-
-        <table style="width:100%">
-            <tr>
-                <th>Resource</th>
-                <th>Method</th>
-                <th>Parameters</th>
-                <th>Request body</th>
-            </tr>
-            <tr>
-                <td>/eiffelsemantics</td>
-                <td>POST</td>
-                <td>msgType</td>
-                <td style="margin:0px;"><pre>
-{
-  "msgParams": {
-    "meta": {
-      # Matches the meta object
-    }
-  },
-  "eventParams": {
-    "data": {
-      # Matches the data object
-    },
-    "links": {
-      # Matches the links object
-    }
-  }
-}</pre>
-                </td>
-            </tr>
-        </table>
-
-        <h3>Versions End point:</h3>
-        <p>"/versions" end point is used to get the versions of messaging protocols along with the current version of generate in a JSON format.<br>
-            URL: http://&lt;host&gt;:&lt;port&gt;/&lt;application name&gt;/versions/
-        </p>
-
-        <p>Sample result:</p>
-
-        <pre>
-        {
-            "serviceVersion": {
-                "version": "x.x.x"
-            },
-            "endpointVersions": {
-                "semanticsVersion": "x.x.x",
-            }
-        }
-        </pre>
-
-        <h3>Ldap configurations:</h3>
-
-        <p>Active Directory authentication can be enabled for the REMReM REST service by setting the configuration property
-            <code>activedirectory.generate.enabled=true</code>.
-        </p>
-
-        <p>To authenticate with active ldap server we have to provide the following configurations in the
-            <strong>tomcat/conf/config.properties</strong> file.
-        </p>
-
-        <pre>
-  activedirectory.ldapUrl         : &lt;LDAP server url&gt;
-  activedirectory.managerPassword : &lt;LDAP server manager password(must be base64 Encrypted format)&gt;
-  activedirectory.managerDn       : &lt;LDAP managerDn pattern&gt;
-  activedirectory.rootDn          : &lt;LDAP rootDn pattern&gt;
-  activedirectory.userSearchFilter: &lt;LDAP userSearchFilter pattern&gt;
-        </pre>
-
-        <p><strong>LDAP authentication without Base64 encryption:</strong></p>
-
-        <pre><code>$ curl -XPOST -H "Content-Type: application/json" --user username:password --data @ActivityCanceled.json http://localhost:8080/generate-service/eiffelsemantics?msgType=eiffelactivitycanceled</code></pre>
-
-        <p align="justify">Each HTTP request must then include an Authorization header with value <code>Basic &lt;Base64 encoded username:password&gt;</code>.</p>
-
-        <p><strong>LDAP authentication with Base64 encryption:</strong></p>
-
-        <pre><code>$ curl -XPOST -H "Content-Type: application/json" -H 'Authorization: Basic cGFzc3dvcmQ=' --data @ActivityCanceled.json http://localhost:8080/generate-service/eiffelsemantics?msgType=eiffelactivitycanceled</code></pre>
-
-
-        <h2>
-            <a id="testing" class="anchor" href="#testing" aria-hidden="true">
-                <span aria-hidden="true" class="octicon octicon-link"></span>
-            </a>Testing
-        </h2>
-
-        <h3>
-            <a id="example-with-event-body-passed-to-service" class="anchor"
-               href="#example-with-event-body-passed-to-service" aria-hidden="true">
-                <span aria-hidden="true" class="octicon octicon-link"></span>
-            </a>Example with event body passed to service:<br>
-        </h3>
-
-        <pre>curl -H "Content-Type: application/json" -X POST -d '{"msgParams": {"meta": {"type": "EiffelActivityFinishedEvent", "tags": ["tag1","tag2"], "source": {"domainId": "example.domain", "host": "host", "name": "name", "uri": "http://java.sun.com/j2se/1.3/", "gav": {"groupId": "com.github.Ericsson", "artifactId": "eiffel-remrem-semantics", "version": "0.2.9"}}, "security": {"sdm": {"authorIdentity": "test", "encryptedDigest": "sample"}}}}, "eventParams": {"data": {"outcome": {"conclusion": "SUCCESSFUL"}, "persistentLogs": [{"name": "firstLog", "uri": "http://myHost.com/firstLog"}, {"name": "otherLog", "uri": "isbn:0-486-27557-4"}]}, "links": [{"type": "ACTIVITY_EXECUTION", "target": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee1"}]}}' http://localhost:8080/generate-service/eiffelsemantics?msgType=eiffelactivityfinished</pre>
-
-        <p><strong>NOTE:</strong> for eiffel-remrem-semantics inputEventType is not mandatory, it will be added based on event type query,
-            but from the input.json the eventType should be camelcase.
-        </p>
-
-        <p><strong>NOTE:</strong> for other than eiffelsemantics protocol, provide the Java opts as:</p>
-        <pre>set JAVA_OPTS="-Djava.ext.dirs=/path/to/jars/" in catalina.sh</pre>
-
-        <p><strong>NOTE:</strong> in the above example, protocol jar file must be present inside "/path/to/jars/" folder.</p>
-
-        <h3>
-            <a id="example-with-event-body-in-a-file-body-singlejson-passed-to-service" class="anchor"
-               href="#example-with-event-body-in-a-file-body-singlejson-passed-to-service" aria-hidden="true">
-                <span aria-hidden="true" class="octicon octicon-link"></span>
-            </a>Example with event body in a file body-single.json passed to service:
-        </h3>
-
-        <pre>curl -XPOST -H "Content-Type: application/json" --data @body-single.json http://localhost:8080/generate-service/eiffelsemantics?msgType=eiffelactivityfinished</pre>
-
-        <h2>Status Codes</h2>
-        <p>HTTP Status Code is the Response Code for the HTTP Request.</p>
-        <table class="wikitable">
-            <tr>
-                <th style="text-align: left;">Status code</th>
-                <th style="text-align: left;">Description</th>
-                <th style="text-align: left;">Comment</th>
-            </tr>
-            <tr>
-                <td>200</td>
-                <td>OK</td>
-                <td>Event sent successfully</td>
-            </tr>
-            <tr>
-                <td>400</td>
-                <td>Bad Request</td>
-                <td>Malformed JSON (missing braces etc..), client need to fix problem in event before submitting again</td>
-            </tr>
-            <tr>
-                <td>500</td>
-                <td>Internal Server Error</td>
-                <td>When REMReM Generate is down, possible to try again later when server is up</td>
-            </tr>
-            <tr>
-                <td>503</td>
-                <td>Service Unavailable</td>
-                <td>When the message protocol is invalid</td>
-            </tr>
-        </table>
 
         <h2>Logging</h2>
 
@@ -454,7 +112,7 @@ usage: java -jar
 <!-- FOOTER  -->
 <div id="footer_wrap" class="outer">
     <footer class="inner">
-        <p class="copyright">Eiffel REMReM Generate maintained by <a href="https://github.com/evasiba-ericsson">evasiba-ericsson</a></p>
+        <p class="copyright">Eiffel REMReM Generate maintained by <a href="https://github.com/ericsson">Ericsson</a></p>
         <p>Published with <a href="https://pages.github.com">GitHub Pages</a></p>
     </footer>
 </div>

--- a/javascripts/download.js
+++ b/javascripts/download.js
@@ -1,0 +1,28 @@
+function getLatestVersion(type,extn){
+                var xhr = new XMLHttpRequest();
+                xhr.open("GET", "https://jitpack.io/v/Ericsson/eiffel-remrem-generate.svg");
+                xhr.responseType = "blob";//force the HTTP response, response-type header to be blob
+                xhr.onload = function()
+                {
+                    var blob = xhr.response;
+                    var reader = new FileReader();
+                    reader.addEventListener("loadend", function() {
+                        var result = reader.result;
+                        if(result=="Repo not found or no access token provided"){
+                            document.getElementById("downloadLink").innerHTML = result;
+                            document.getElementById("downloadLink").style.visibility = "";
+                        }
+                        else{
+                            document.getElementById("downloadLink").innerHTML = result;
+                            var val = document.getElementsByTagName("text")[2].innerHTML;
+                            val = val.trim();
+                            urlLink = "https://jitpack.io/com/github/Ericsson/eiffel-remrem-generate/generate-"+type +"/"+val+"/generate-"+type +"-"+val+"."+extn;
+                            var link = document.createElement("a");
+                            link.href = urlLink;
+                            link.click();
+                        }
+                    });
+                    reader.readAsBinaryString(blob);
+                }
+                xhr.send();
+            }

--- a/javascripts/download.js
+++ b/javascripts/download.js
@@ -1,28 +1,26 @@
 function getLatestVersion(type,extn){
-                var xhr = new XMLHttpRequest();
-                xhr.open("GET", "https://jitpack.io/v/Ericsson/eiffel-remrem-generate.svg");
-                xhr.responseType = "blob";//force the HTTP response, response-type header to be blob
-                xhr.onload = function()
-                {
-                    var blob = xhr.response;
-                    var reader = new FileReader();
-                    reader.addEventListener("loadend", function() {
-                        var result = reader.result;
-                        if(result=="Repo not found or no access token provided"){
-                            document.getElementById("downloadLink").innerHTML = result;
-                            document.getElementById("downloadLink").style.visibility = "";
-                        }
-                        else{
-                            document.getElementById("downloadLink").innerHTML = result;
-                            var val = document.getElementsByTagName("text")[2].innerHTML;
-                            val = val.trim();
-                            urlLink = "https://jitpack.io/com/github/Ericsson/eiffel-remrem-generate/generate-"+type +"/"+val+"/generate-"+type +"-"+val+"."+extn;
-                            var link = document.createElement("a");
-                            link.href = urlLink;
-                            link.click();
-                        }
-                    });
-                    reader.readAsBinaryString(blob);
-                }
-                xhr.send();
+    var xhr = new XMLHttpRequest();
+    xhr.open("GET", "https://jitpack.io/v/Ericsson/eiffel-remrem-generate.svg");
+    xhr.responseType = "blob";//force the HTTP response, response-type header to be blob
+    xhr.onload = function() {
+        var blob = xhr.response;
+        var reader = new FileReader();
+        reader.addEventListener("loadend", function() {
+            var result = reader.result;
+            if(result=="Repo not found or no access token provided"){
+                document.getElementById("downloadLink").innerHTML = result;
+                document.getElementById("downloadLink").style.visibility = "";
+            }else{
+                document.getElementById("downloadLink").innerHTML = result;
+                var val = document.getElementsByTagName("text")[2].innerHTML;
+                val = val.trim();
+                urlLink = "https://jitpack.io/com/github/Ericsson/eiffel-remrem-generate/generate-"+type +"/"+val+"/generate-"+type +"-"+val+"."+extn;
+                var link = document.createElement("a");
+                link.href = urlLink;
+                link.click();
             }
+        });
+        reader.readAsBinaryString(blob);
+    }
+    xhr.send();
+}

--- a/serviceUsage.html
+++ b/serviceUsage.html
@@ -234,7 +234,7 @@ activedirectory.userSearchFilter: &lt;LDAP userSearchFilter pattern&gt;</pre>
         </h3>
         <pre><code>curl -H "Content-Type: application/json" -X GET http://localhost:8080/generate/versions</code></pre>
         <p>Result:</p>
-        <pre>{"serviceVersion":{"version":"x.x.x"},"endpointVersions":{"semanticsVersion":"x.x.x","eiffel3MessagingVersion":"x.x.x"}}</pre>
+        <pre>{"serviceVersion":{"version":"x.x.x"},"endpointVersions":{"semanticsVersion":"x.x.x"}}</pre>
 
         <h2>
             <a id="status-codes" class="anchor" href="#status-codes" aria-hidden="true">

--- a/serviceUsage.html
+++ b/serviceUsage.html
@@ -1,0 +1,295 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <meta charset='utf-8'>
+    <meta http-equiv="X-UA-Compatible" content="chrome=1">
+    <meta name="description" content="Eiffel-remrem-generate : eiffel-remrem-generate">
+
+    <link rel="stylesheet" type="text/css" media="screen" href="stylesheets/stylesheet.css">
+
+    <title>Eiffel REMReM Generate</title>
+</head>
+
+<body>
+
+<!-- HEADER -->
+<div id="header_wrap" class="outer">
+    <header class="inner">
+        <a id="forkme_banner" href="https://github.com/Ericsson/eiffel-remrem-generate">View on GitHub</a>
+
+        <h1><a class="project_title" href="index.html#project_title">Eiffel REMReM Generate</a></h1>
+
+        <section id="downloads">
+            <a class="zip_download_link" href="https://github.com/Ericsson/eiffel-remrem-generate/zipball/master">Download this project as a .zip
+                file</a>
+            <a class="tar_download_link" href="https://github.com/Ericsson/eiffel-remrem-generate/tarball/master">Download this project as a tar.gz
+                file</a>
+        </section>
+    </header>
+</div>
+
+<!-- MAIN CONTENT -->
+<div id="main_content_wrap" class="outer">
+    <section id="main_content" class="inner">
+        <h1>
+            <a id="remrem-generate-service" class="anchor" href="#remrem-generate-service" aria-hidden="true">
+                <span aria-hidden="true" class="octicon octicon-link"></span>
+            </a>REMReM Generate Service
+        </h1>
+
+        <p>REMReM Generate Service allows generating of Eiffel messages that will be send by <a
+                href="http://ericsson.github.io/eiffel-remrem-semantics/">Eiffel REMReM Publish</a> to RabbitMQ</p>
+
+        <p>Information about the REMReM Generate Service all endpoints can be got and easily accessed using next links:</p>
+        <pre>http://&lt;host&gt;:&lt;port&gt;/&lt;application name&gt;/</pre>
+        or
+        <pre>http://&lt;host&gt;:&lt;port&gt;/&lt;application name&gt;/swagger-ui.html</pre>
+
+        <p>Example:</p>
+        <pre>http://localhost:8080/generate/</pre>
+
+        <h2>
+            <a id="configuration" class="anchor" href="#configuration" aria-hidden="true">
+                <span aria-hidden="true" class="octicon octicon-link"></span>
+            </a>Configuration
+        </h2>
+
+        <p>For using Eiffel REMReM Service <strong>generate-service.war</strong> file should be deployed in Tomcat Server.
+            For doing this, generate-service.war file should locate in next directory: <em>tomcat/webapps</em>.
+        </p>
+
+        <p>Configuration is done in Tomcat using a config.properties file: <em>tomcat/conf/config.properties</em>.</p>
+
+        <p><strong>NOTE:</strong> in each example assuming the generate-service.war is deployed in tomcat as <strong>generate</strong>.</p>
+        <p><strong>NOTE:</strong> for other than eiffelsemantics protocol, provide the Java opts as:</p>
+        <pre>set JAVA_OPTS="-Djava.ext.dirs=/path/to/jars/" in catalina.sh</pre>
+        <p><strong>NOTE:</strong> in the above example, protocol jar file must be present inside "/path/to/jars/" folder.</p>
+
+        <h3>Ldap configurations:</h3>
+
+        <p>Active Directory authentication can be enabled for the REMReM REST service by setting the configuration property
+            <code>activedirectory.generate.enabled=true</code>.
+        </p>
+
+        <p>To authenticate with active ldap server we have to provide the following configurations in the
+            <strong>tomcat/conf/config.properties</strong> file.
+        </p>
+
+        <pre>
+  activedirectory.ldapUrl         : &lt;LDAP server url&gt;
+  activedirectory.managerPassword : &lt;LDAP server manager password(must be base64 Encrypted format)&gt;
+  activedirectory.managerDn       : &lt;LDAP managerDn pattern&gt;
+  activedirectory.rootDn          : &lt;LDAP rootDn pattern&gt;
+  activedirectory.userSearchFilter: &lt;LDAP userSearchFilter pattern&gt;
+        </pre>
+        <p><strong>LDAP authentication without Base64 encryption:</strong></p>
+
+        <pre><code>$ curl -XPOST -H "Content-Type: application/json" --user username:password --data @ActivityCanceled.json http://localhost:8080/generate-service/eiffelsemantics?msgType=eiffelactivitycanceled</code></pre>
+
+        <p align="justify">Each HTTP request must then include an Authorization header with value <code>Basic &lt;Base64 encoded
+            username:password&gt;</code>.</p>
+
+        <p><strong>LDAP authentication with Base64 encryption:</strong></p>
+
+        <pre><code>$ curl -XPOST -H "Content-Type: application/json" -H 'Authorization: Basic cGFzc3dvcmQ=' --data @ActivityCanceled.json http://localhost:8080/generate-service/eiffelsemantics?msgType=eiffelactivitycanceled</code></pre>
+
+
+        <p>Available REST resources for generate are:</p>
+
+        <table style="width:100%">
+            <tr>
+                <th>Resource</th>
+                <th>Method</th>
+                <th>Parameters</th>
+                <th style="margin:0px;">Request body</th>
+                <th width="20%">Description</th>
+            </tr>
+            <tr>
+                <td>/event_types/{mp}</td>
+                <td>GET</td>
+                <td>
+                    <p>mp - message protocol, required</p>
+                </td>
+                <td>
+                </td>
+                <td>This endpoint is used to obtain Eiffel event types implemented in <a href="http://ericsson.github.io/eiffel-remrem-semantics/">Eiffel
+                    REMReM Semantics</a>.
+                </td>
+            </tr>
+
+            <tr>
+                <td>/template/{type}/{mp}</td>
+                <td>GET</td>
+                <td>
+                    <p>type - Eiffel event type</p>
+                    <p>mp - message protocol, required</p>
+                </td>
+                <td>
+                </td>
+                <td>This endpoint is used to obtain Eiffel event templates implemented in <a
+                        href="http://ericsson.github.io/eiffel-remrem-semantics/">Eiffel
+                    REMReM Semantics</a>.
+                </td>
+            </tr>
+
+            <tr>
+                <td>/mp</td>
+                <td>POST</td>
+                <td>
+                    <p>mp - message protocol, required</p>
+                    <p>msgType - Eiffel event type, required</p>
+                    <p>bodyJson - message body, required</p>
+                </td>
+                <td>
+<pre>{
+  "msgParams": {
+    "meta": {
+      # Matches the meta object
+    }
+  },
+  "eventParams": {
+    "data": {
+      # Matches the data object
+    },
+    "links": {
+      # Matches the links object
+    }
+  }
+}</pre>
+                </td>
+                <td>
+                    <p>This endpoint is used to generate Eiffel events and then the obtained event could be published by
+                        <a href="http://ericsson.github.io/eiffel-remrem-publish/">Eiffel REMReM Publish</a>.</p>
+                </td>
+            </tr>
+            <tr>
+                <td>/versions</td>
+                <td>GET</td>
+                <td></td>
+                <td></td>
+                <td>This endpoint is used to get versions of generate service and all loaded protocols versions in JSON format.</td>
+            </tr>
+        </table>
+
+
+        <h2>
+            <a id="examples" class="anchor" href="#examples" aria-hidden="true">
+                <span aria-hidden="true" class="octicon octicon-link"></span>
+            </a>Examples
+        </h2>
+
+        <h3>
+            <a id="example1" class="anchor"
+               href="#example1" aria-hidden="true">
+                <span aria-hidden="true" class="octicon octicon-link"></span>
+            </a>Examples for <code>/event_types/{mp}</code> endpoint
+        </h3>
+        <h5>
+            Retrieve the event types
+        </h5>
+        <pre>curl -X GET --header 'Accept: application/json' 'http://localhost:8080/generate-service/event_types/eiffelsemantics'</pre>
+        <p>Result</p>
+        <pre>["EiffelArtifactPublishedEvent","EiffelActivityFinishedEvent","EiffelActivityCanceledEvent","EiffelArtifactCreatedEvent","EiffelActivityTriggeredEvent","EiffelConfidenceLevelModifiedEvent","EiffelActivityStartedEvent","EiffelAnnouncementPublishedEvent","EiffelCompositionDefinedEvent","EiffelTestCaseCanceledEvent","EiffelTestCaseTriggeredEvent","EiffelTestExecutionRecipeCollectionCreatedEvent","EiffelEnvironmentDefinedEvent","EiffelFlowContextDefinedEvent","EiffelSourceChangeCreatedEvent","EiffelSourceChangeSubmittedEvent","EiffelTestCaseFinishedEvent","EiffelTestCaseStartedEvent","EiffelTestSuiteFinishedEvent","EiffelTestSuiteStartedEvent","EiffelIssueVerifiedEvent","EiffelArtifactReusedEvent","EiffelServiceStoppedEvent","EiffelServiceStartedEvent","EiffelServiceReturnedEvent","EiffelServiceDiscontinuedEvent","EiffelServiceDeployedEvent","EiffelServiceAllocatedEvent","EiffelArtifactDeployedEvent","EiffelAlertAcknowledgedEvent","EiffelAlertCeasedEvent","EiffelAlertRaisedEvent"]
+</pre>
+
+        <h3>
+            <a id="example2" class="anchor"
+               href="#example2" aria-hidden="true">
+                <span aria-hidden="true" class="octicon octicon-link"></span>
+            </a>Examples for <code>/template/{type}/{mp}</code> endpoint
+        </h3>
+        <h5>
+            Retrieve the event template
+        </h5>
+        <pre>curl -X GET --header 'Accept: application/json' 'http://localhost:8080/generate-service/template/EiffelArtifactPublishedEvent/eiffelsemantics'</pre>
+        <p>Result</p>
+        <pre>{"msgParams":{"meta":{"type":"EiffelArtifactPublishedEvent","version":"1.1.0","tags":[],"source":{"domainId":"","host":"","name":"","uri":""},"security":{"sdm":{"authorIdentity":"required if sdm present","encryptedDigest":"required if sdm present"}}}},"eventParams":{"data":{"locations":[{"type":"required ,can be anyone of ARTIFACTORY,NEXUS,PLAIN,OTHER","uri":"required"}],"customData":[{"key":"required if customData present","value":"required if customData present"}]},"links":[{"type":"required ARTIFACT and CAUSE,CONTEXT,FLOW_CONTEXT are optional","target":"required"}]}}
+</pre>
+
+        <h3>
+            <a id="example3" class="anchor"
+               href="#example3" aria-hidden="true">
+                <span aria-hidden="true" class="octicon octicon-link"></span>
+            </a>Examples for <code>/mp</code> endpoint
+        </h3>
+        <h5>Given one message in file body-single.json</h5>
+        <pre>curl -XPOST -H "Content-Type: application/json" --data @body-single.json http://localhost:8080/generate-service/eiffelsemantics?msgType=eiffelactivityfinished</pre>
+        <p>Result:</p>
+        <pre>[{"meta":{"id":"7d8ea04d-b5a6-459f-a6fe-134e55556f0b","type":"EiffelActivityFinishedEvent","version":"1.1.0","time":1521545563096,"tags":["tag1","tag2"],"source":{"domainId":"example.domain","host":"host","name":"name","serializer":{"groupId":"com.github.Ericsson","artifactId":"eiffel-remrem-semantics","version":"0.4.0"},"uri":"http://java.sun.com/j2se/1.3/"},"security":{"sdm":{"authorIdentity":"test","encryptedDigest":"sample"}}},"data":{"outcome":{"conclusion":"SUCCESSFUL"},"persistentLogs":[{"name":"firstLog","uri":"http://myHost.com/firstLog"},{"name":"otherLog","uri":"isbn:0-486-27557-4"}],"customData":[]},"links":[{"type":"ACTIVITY_EXECUTION","target":"aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee1"}]}]</pre>
+
+        <h5>
+            <a id="example-with-event-body-passed-to-service" class="anchor"
+               href="#example-with-event-body-passed-to-service" aria-hidden="true">
+                <span aria-hidden="true" class="octicon octicon-link"></span>
+            </a>Example with event body passed to service:<br>
+        </h5>
+        <pre>curl -H "Content-Type: application/json" -X POST -d '{"msgParams": {"meta": {"type": "EiffelActivityFinishedEvent", "tags": ["tag1","tag2"], "source": {"domainId": "example.domain", "host": "host", "name": "name", "uri": "http://java.sun.com/j2se/1.3/", "gav": {"groupId": "com.github.Ericsson", "artifactId": "eiffel-remrem-semantics", "version": "0.2.9"}}, "security": {"sdm": {"authorIdentity": "test", "encryptedDigest": "sample"}}}}, "eventParams": {"data": {"outcome": {"conclusion": "SUCCESSFUL"}, "persistentLogs": [{"name": "firstLog", "uri": "http://myHost.com/firstLog"}, {"name": "otherLog", "uri": "isbn:0-486-27557-4"}]}, "links": [{"type": "ACTIVITY_EXECUTION", "target": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee1"}]}}' http://localhost:8080/generate-service/eiffelsemantics?msgType=eiffelactivityfinished</pre>
+        <p>Result:</p>
+        <pre>[{"meta":{"id":"7d8ea04d-b5a6-459f-a6fe-134e55556f0b","type":"EiffelActivityFinishedEvent","version":"1.1.0","time":1521545563096,"tags":["tag1","tag2"],"source":{"domainId":"example.domain","host":"host","name":"name","serializer":{"groupId":"com.github.Ericsson","artifactId":"eiffel-remrem-semantics","version":"0.4.0"},"uri":"http://java.sun.com/j2se/1.3/"},"security":{"sdm":{"authorIdentity":"test","encryptedDigest":"sample"}}},"data":{"outcome":{"conclusion":"SUCCESSFUL"},"persistentLogs":[{"name":"firstLog","uri":"http://myHost.com/firstLog"},{"name":"otherLog","uri":"isbn:0-486-27557-4"}],"customData":[]},"links":[{"type":"ACTIVITY_EXECUTION","target":"aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee1"}]}]</pre>
+
+        <!--versions-->
+        <h3>
+            <a id="examples4" class="anchor" href="#examples4" aria-hidden="true">
+                <span aria-hidden="true" class="octicon octicon-link"></span>
+            </a>Examples for <code>/versions</code> endpoint
+        </h3>
+        <pre><code>curl -H "Content-Type: application/json" -X GET http://localhost:8080/generate/versions</code></pre>
+        <p>Result:</p>
+        <pre>{"serviceVersion":{"version":"x.x.x"},"endpointVersions":{"semanticsVersion":"x.x.x","eiffel3MessagingVersion":"x.x.x"}}</pre>
+
+
+        <h2>Status Codes</h2>
+        <p>HTTP Status Code is the Response Code for the HTTP Request.</p>
+        <table class="wikitable">
+            <tr>
+                <th style="text-align: left;">Status code</th>
+                <th style="text-align: left;">Result</th>
+                <th style="text-align: left;">Message</th>
+                <th style="text-align: left;">Comment</th>
+            </tr>
+            <tr>
+                <td>200</td>
+                <td>OK</td>
+                <td></td>
+                <td>Event generated successfully</td>
+            </tr>
+            <tr>
+                <td>400</td>
+                <td>Bad Request</td>
+                <td>Could not read document: Unrecognized token</td>
+                <td>Malformed JSON (missing braces or wrong event type, etc..), client need to fix problem in event before submitting again</td>
+            </tr>
+            <tr>
+                <td>404</td>
+                <td>Not Found</td>
+                <td>Requested template is not available</td>
+                <td>The endpoint is not found, or template for specified event type is not found</td>
+            </tr>
+            <tr>
+                <td>500</td>
+                <td>Internal Server Error</td>
+                <td>Internal server error</td>
+                <td>When REMReM Generate is down, possible to try again later when server is up</td>
+            </tr>
+            <tr>
+                <td>503</td>
+                <td>Service Unavailable</td>
+                <td>"No protocol service has been found registered"</td>
+                <td>When specified message protocol is not loaded</td>
+            </tr>
+        </table>
+
+    </section>
+</div>
+
+<!-- FOOTER  -->
+<div id="footer_wrap" class="outer">
+    <footer class="inner">
+        <p class="copyright">Eiffel REMReM Generate maintained by <a href="https://github.com/ericsson">Ericsson</a></p>
+        <p>Published with <a href="https://pages.github.com">GitHub Pages</a></p>
+    </footer>
+</div>
+
+</body>
+</html>

--- a/serviceUsage.html
+++ b/serviceUsage.html
@@ -39,7 +39,7 @@
         </h1>
 
         <p>REMReM Generate Service allows generating of Eiffel messages that will be send by <a
-                href="http://ericsson.github.io/eiffel-remrem-semantics/">Eiffel REMReM Publish</a> to RabbitMQ</p>
+                href="http://ericsson.github.io/eiffel-remrem-semantics/">Eiffel REMReM Publish</a> to RabbitMQ.</p>
 
         <p>Information about the REMReM Generate Service all endpoints can be got and easily accessed using next links:</p>
         <pre>http://&lt;host&gt;:&lt;port&gt;/&lt;application name&gt;/</pre>
@@ -66,36 +66,40 @@
         <pre>set JAVA_OPTS="-Djava.ext.dirs=/path/to/jars/" in catalina.sh</pre>
         <p><strong>NOTE:</strong> in the above example, protocol jar file must be present inside "/path/to/jars/" folder.</p>
 
-        <h3>Ldap configurations:</h3>
+        <h3>Ldap authentication configurations</h3>
 
         <p>Active Directory authentication can be enabled for the REMReM REST service by setting the configuration property
-            <code>activedirectory.generate.enabled=true</code>.
+            <code>activedirectory.generate.enabled: true</code>.
         </p>
 
-        <p>To authenticate with active ldap server we have to provide the following configurations in the
-            <strong>tomcat/conf/config.properties</strong> file.
-        </p>
+        <p><strong>NOTE:</strong> it is recommended to disable ldap authentication for REMReM Publish Service
+            for correct work of REMReM Publish Service endpoint <code>/generateAndPublish</code>.</p>
 
         <pre>
-  activedirectory.ldapUrl         : &lt;LDAP server url&gt;
-  activedirectory.managerPassword : &lt;LDAP server manager password(must be base64 Encrypted format)&gt;
-  activedirectory.managerDn       : &lt;LDAP managerDn pattern&gt;
-  activedirectory.rootDn          : &lt;LDAP rootDn pattern&gt;
-  activedirectory.userSearchFilter: &lt;LDAP userSearchFilter pattern&gt;
-        </pre>
+activedirectory.generate.enabled: &lt;true | false&gt;
+activedirectory.ldapUrl:          &lt;LDAP server url&gt;
+activedirectory.managerPassword:  &lt;LDAP server manager password(must be base64 Encrypted format)&gt;
+activedirectory.managerDn:        &lt;LDAP managerDn pattern&gt;
+activedirectory.rootDn:           &lt;LDAP rootDn pattern&gt;
+activedirectory.userSearchFilter: &lt;LDAP userSearchFilter pattern&gt;</pre>
+
         <p><strong>LDAP authentication without Base64 encryption:</strong></p>
 
         <pre><code>$ curl -XPOST -H "Content-Type: application/json" --user username:password --data @ActivityCanceled.json http://localhost:8080/generate-service/eiffelsemantics?msgType=eiffelactivitycanceled</code></pre>
 
-        <p align="justify">Each HTTP request must then include an Authorization header with value <code>Basic &lt;Base64 encoded
-            username:password&gt;</code>.</p>
+        <p><strong>NOTE:</strong> each HTTP request must then include an Authorization header with value
+            <code>Basic &lt;Base64 encoded username:password&gt;</code>.</p>
 
         <p><strong>LDAP authentication with Base64 encryption:</strong></p>
 
         <pre><code>$ curl -XPOST -H "Content-Type: application/json" -H 'Authorization: Basic cGFzc3dvcmQ=' --data @ActivityCanceled.json http://localhost:8080/generate-service/eiffelsemantics?msgType=eiffelactivitycanceled</code></pre>
 
-
-        <p>Available REST resources for generate are:</p>
+        <h2>
+            <a id="usage" class="anchor" href="#usage" aria-hidden="true">
+                <span aria-hidden="true" class="octicon octicon-link"></span>
+            </a>Usage
+        </h2>
+        <p>Available REST resources for REMReM Generate Service are described below:</p>
 
         <table style="width:100%">
             <tr>
@@ -106,40 +110,11 @@
                 <th width="20%">Description</th>
             </tr>
             <tr>
-                <td>/event_types/{mp}</td>
-                <td>GET</td>
-                <td>
-                    <p>mp - message protocol, required</p>
-                </td>
-                <td>
-                </td>
-                <td>This endpoint is used to obtain Eiffel event types implemented in <a href="http://ericsson.github.io/eiffel-remrem-semantics/">Eiffel
-                    REMReM Semantics</a>.
-                </td>
-            </tr>
-
-            <tr>
-                <td>/template/{type}/{mp}</td>
-                <td>GET</td>
-                <td>
-                    <p>type - Eiffel event type</p>
-                    <p>mp - message protocol, required</p>
-                </td>
-                <td>
-                </td>
-                <td>This endpoint is used to obtain Eiffel event templates implemented in <a
-                        href="http://ericsson.github.io/eiffel-remrem-semantics/">Eiffel
-                    REMReM Semantics</a>.
-                </td>
-            </tr>
-
-            <tr>
                 <td>/mp</td>
                 <td>POST</td>
                 <td>
                     <p>mp - message protocol, required</p>
                     <p>msgType - Eiffel event type, required</p>
-                    <p>bodyJson - message body, required</p>
                 </td>
                 <td>
 <pre>{
@@ -164,6 +139,32 @@
                 </td>
             </tr>
             <tr>
+                <td>/event_types/{mp}</td>
+                <td>GET</td>
+                <td>
+                    <p>mp - message protocol, required</p>
+                </td>
+                <td>
+                </td>
+                <td>This endpoint is used to obtain Eiffel event types implemented in <a href="http://ericsson.github.io/eiffel-remrem-semantics/">Eiffel
+                    REMReM Semantics</a>.
+                </td>
+            </tr>
+            <tr>
+                <td>/template/{type}/{mp}</td>
+                <td>GET</td>
+                <td>
+                    <p>type - Eiffel event type</p>
+                    <p>mp - message protocol, required</p>
+                </td>
+                <td>
+                </td>
+                <td>This endpoint is used to obtain Eiffel event templates implemented in <a
+                        href="http://ericsson.github.io/eiffel-remrem-semantics/">Eiffel
+                    REMReM Semantics</a>.
+                </td>
+            </tr>
+            <tr>
                 <td>/versions</td>
                 <td>GET</td>
                 <td></td>
@@ -172,63 +173,60 @@
             </tr>
         </table>
 
-
         <h2>
             <a id="examples" class="anchor" href="#examples" aria-hidden="true">
                 <span aria-hidden="true" class="octicon octicon-link"></span>
             </a>Examples
         </h2>
+        <p>Typical examples of usage Eiffel REMReM Generate Service endpoints are described below.</p>
+
+        <p>You can use command line tools like <a href="https://en.wikipedia.org/wiki/CURL">curl</a> or some plugin for your favorite browser. For example:</p>
+
+        <ul>
+            <li>
+                <a href="https://chrome.google.com/webstore/detail/postman/fhbjgbiflinjbdggehcddcbncdddomop">Postman</a> for Chromium-based browsers
+            </li>
+            <li>
+                <a href="https://addons.mozilla.org/en-US/firefox/addon/httprequester/">HttpRequester</a> for Firefox
+            </li>
+        </ul>
 
         <h3>
             <a id="example1" class="anchor"
                href="#example1" aria-hidden="true">
                 <span aria-hidden="true" class="octicon octicon-link"></span>
-            </a>Examples for <code>/event_types/{mp}</code> endpoint
-        </h3>
-        <h5>
-            Retrieve the event types
-        </h5>
-        <pre>curl -X GET --header 'Accept: application/json' 'http://localhost:8080/generate-service/event_types/eiffelsemantics'</pre>
-        <p>Result</p>
-        <pre>["EiffelArtifactPublishedEvent","EiffelActivityFinishedEvent","EiffelActivityCanceledEvent","EiffelArtifactCreatedEvent","EiffelActivityTriggeredEvent","EiffelConfidenceLevelModifiedEvent","EiffelActivityStartedEvent","EiffelAnnouncementPublishedEvent","EiffelCompositionDefinedEvent","EiffelTestCaseCanceledEvent","EiffelTestCaseTriggeredEvent","EiffelTestExecutionRecipeCollectionCreatedEvent","EiffelEnvironmentDefinedEvent","EiffelFlowContextDefinedEvent","EiffelSourceChangeCreatedEvent","EiffelSourceChangeSubmittedEvent","EiffelTestCaseFinishedEvent","EiffelTestCaseStartedEvent","EiffelTestSuiteFinishedEvent","EiffelTestSuiteStartedEvent","EiffelIssueVerifiedEvent","EiffelArtifactReusedEvent","EiffelServiceStoppedEvent","EiffelServiceStartedEvent","EiffelServiceReturnedEvent","EiffelServiceDiscontinuedEvent","EiffelServiceDeployedEvent","EiffelServiceAllocatedEvent","EiffelArtifactDeployedEvent","EiffelAlertAcknowledgedEvent","EiffelAlertCeasedEvent","EiffelAlertRaisedEvent"]
-</pre>
-
-        <h3>
-            <a id="example2" class="anchor"
-               href="#example2" aria-hidden="true">
-                <span aria-hidden="true" class="octicon octicon-link"></span>
-            </a>Examples for <code>/template/{type}/{mp}</code> endpoint
-        </h3>
-        <h5>
-            Retrieve the event template
-        </h5>
-        <pre>curl -X GET --header 'Accept: application/json' 'http://localhost:8080/generate-service/template/EiffelArtifactPublishedEvent/eiffelsemantics'</pre>
-        <p>Result</p>
-        <pre>{"msgParams":{"meta":{"type":"EiffelArtifactPublishedEvent","version":"1.1.0","tags":[],"source":{"domainId":"","host":"","name":"","uri":""},"security":{"sdm":{"authorIdentity":"required if sdm present","encryptedDigest":"required if sdm present"}}}},"eventParams":{"data":{"locations":[{"type":"required ,can be anyone of ARTIFACTORY,NEXUS,PLAIN,OTHER","uri":"required"}],"customData":[{"key":"required if customData present","value":"required if customData present"}]},"links":[{"type":"required ARTIFACT and CAUSE,CONTEXT,FLOW_CONTEXT are optional","target":"required"}]}}
-</pre>
-
-        <h3>
-            <a id="example3" class="anchor"
-               href="#example3" aria-hidden="true">
-                <span aria-hidden="true" class="octicon octicon-link"></span>
             </a>Examples for <code>/mp</code> endpoint
         </h3>
-        <h5>Given one message in file body-single.json</h5>
+        <h5>Given one message in file <em>body-single.json</em>:</h5>
         <pre>curl -XPOST -H "Content-Type: application/json" --data @body-single.json http://localhost:8080/generate-service/eiffelsemantics?msgType=eiffelactivityfinished</pre>
         <p>Result:</p>
         <pre>[{"meta":{"id":"7d8ea04d-b5a6-459f-a6fe-134e55556f0b","type":"EiffelActivityFinishedEvent","version":"1.1.0","time":1521545563096,"tags":["tag1","tag2"],"source":{"domainId":"example.domain","host":"host","name":"name","serializer":{"groupId":"com.github.Ericsson","artifactId":"eiffel-remrem-semantics","version":"0.4.0"},"uri":"http://java.sun.com/j2se/1.3/"},"security":{"sdm":{"authorIdentity":"test","encryptedDigest":"sample"}}},"data":{"outcome":{"conclusion":"SUCCESSFUL"},"persistentLogs":[{"name":"firstLog","uri":"http://myHost.com/firstLog"},{"name":"otherLog","uri":"isbn:0-486-27557-4"}],"customData":[]},"links":[{"type":"ACTIVITY_EXECUTION","target":"aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee1"}]}]</pre>
 
-        <h5>
-            <a id="example-with-event-body-passed-to-service" class="anchor"
-               href="#example-with-event-body-passed-to-service" aria-hidden="true">
-                <span aria-hidden="true" class="octicon octicon-link"></span>
-            </a>Example with event body passed to service:<br>
-        </h5>
+        <h5>Example with event body passed to service:</h5>
         <pre>curl -H "Content-Type: application/json" -X POST -d '{"msgParams": {"meta": {"type": "EiffelActivityFinishedEvent", "tags": ["tag1","tag2"], "source": {"domainId": "example.domain", "host": "host", "name": "name", "uri": "http://java.sun.com/j2se/1.3/", "gav": {"groupId": "com.github.Ericsson", "artifactId": "eiffel-remrem-semantics", "version": "0.2.9"}}, "security": {"sdm": {"authorIdentity": "test", "encryptedDigest": "sample"}}}}, "eventParams": {"data": {"outcome": {"conclusion": "SUCCESSFUL"}, "persistentLogs": [{"name": "firstLog", "uri": "http://myHost.com/firstLog"}, {"name": "otherLog", "uri": "isbn:0-486-27557-4"}]}, "links": [{"type": "ACTIVITY_EXECUTION", "target": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee1"}]}}' http://localhost:8080/generate-service/eiffelsemantics?msgType=eiffelactivityfinished</pre>
         <p>Result:</p>
         <pre>[{"meta":{"id":"7d8ea04d-b5a6-459f-a6fe-134e55556f0b","type":"EiffelActivityFinishedEvent","version":"1.1.0","time":1521545563096,"tags":["tag1","tag2"],"source":{"domainId":"example.domain","host":"host","name":"name","serializer":{"groupId":"com.github.Ericsson","artifactId":"eiffel-remrem-semantics","version":"0.4.0"},"uri":"http://java.sun.com/j2se/1.3/"},"security":{"sdm":{"authorIdentity":"test","encryptedDigest":"sample"}}},"data":{"outcome":{"conclusion":"SUCCESSFUL"},"persistentLogs":[{"name":"firstLog","uri":"http://myHost.com/firstLog"},{"name":"otherLog","uri":"isbn:0-486-27557-4"}],"customData":[]},"links":[{"type":"ACTIVITY_EXECUTION","target":"aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee1"}]}]</pre>
 
-        <!--versions-->
+        <h3>
+            <a id="example2" class="anchor" href="#example2" aria-hidden="true">
+                <span aria-hidden="true" class="octicon octicon-link"></span>
+            </a>Examples for <code>/event_types/{mp}</code> endpoint
+        </h3>
+        <h5>Retrieve the event types:</h5>
+        <pre>curl -X GET --header 'Accept: application/json' 'http://localhost:8080/generate-service/event_types/eiffelsemantics'</pre>
+        <p>Result:</p>
+        <pre>["EiffelArtifactPublishedEvent","EiffelActivityFinishedEvent","EiffelActivityCanceledEvent","EiffelArtifactCreatedEvent","EiffelActivityTriggeredEvent","EiffelConfidenceLevelModifiedEvent","EiffelActivityStartedEvent","EiffelAnnouncementPublishedEvent","EiffelCompositionDefinedEvent","EiffelTestCaseCanceledEvent","EiffelTestCaseTriggeredEvent","EiffelTestExecutionRecipeCollectionCreatedEvent","EiffelEnvironmentDefinedEvent","EiffelFlowContextDefinedEvent","EiffelSourceChangeCreatedEvent","EiffelSourceChangeSubmittedEvent","EiffelTestCaseFinishedEvent","EiffelTestCaseStartedEvent","EiffelTestSuiteFinishedEvent","EiffelTestSuiteStartedEvent","EiffelIssueVerifiedEvent","EiffelArtifactReusedEvent","EiffelServiceStoppedEvent","EiffelServiceStartedEvent","EiffelServiceReturnedEvent","EiffelServiceDiscontinuedEvent","EiffelServiceDeployedEvent","EiffelServiceAllocatedEvent","EiffelArtifactDeployedEvent","EiffelAlertAcknowledgedEvent","EiffelAlertCeasedEvent","EiffelAlertRaisedEvent"]</pre>
+
+        <h3>
+            <a id="example3" class="anchor" href="#example3" aria-hidden="true">
+                <span aria-hidden="true" class="octicon octicon-link"></span>
+            </a>Examples for <code>/template/{type}/{mp}</code> endpoint
+        </h3>
+        <h5>Retrieve the event template:</h5>
+        <pre>curl -X GET --header 'Accept: application/json' 'http://localhost:8080/generate-service/template/EiffelArtifactPublishedEvent/eiffelsemantics'</pre>
+        <p>Result:</p>
+        <pre>{"msgParams":{"meta":{"type":"EiffelArtifactPublishedEvent","version":"1.1.0","tags":[],"source":{"domainId":"","host":"","name":"","uri":""},"security":{"sdm":{"authorIdentity":"required if sdm present","encryptedDigest":"required if sdm present"}}}},"eventParams":{"data":{"locations":[{"type":"required ,can be anyone of ARTIFACTORY,NEXUS,PLAIN,OTHER","uri":"required"}],"customData":[{"key":"required if customData present","value":"required if customData present"}]},"links":[{"type":"required ARTIFACT and CAUSE,CONTEXT,FLOW_CONTEXT are optional","target":"required"}]}}</pre>
+
         <h3>
             <a id="examples4" class="anchor" href="#examples4" aria-hidden="true">
                 <span aria-hidden="true" class="octicon octicon-link"></span>
@@ -238,9 +236,13 @@
         <p>Result:</p>
         <pre>{"serviceVersion":{"version":"x.x.x"},"endpointVersions":{"semanticsVersion":"x.x.x","eiffel3MessagingVersion":"x.x.x"}}</pre>
 
-
-        <h2>Status Codes</h2>
-        <p>HTTP Status Code is the Response Code for the HTTP Request.</p>
+        <h2>
+            <a id="status-codes" class="anchor" href="#status-codes" aria-hidden="true">
+                <span aria-hidden="true" class="octicon octicon-link"></span>
+            </a>Status Codes
+        </h2>
+        <p>The response generated will have internal status codes for each and every event based on the input JSON provided.</p>
+        <p>Status codes are generated according to the below table.</p>
         <table class="wikitable">
             <tr>
                 <th style="text-align: left;">Status code</th>

--- a/stylesheets/stylesheet.css
+++ b/stylesheets/stylesheet.css
@@ -303,12 +303,17 @@ Full-Width Styles
   padding: 50px 10px 30px 10px;
 }
 
-#project_title {
+.project_title {
   margin: 0;
-  color: #fff;
+  color: #fff !important;
   font-size: 42px;
   font-weight: 700;
   text-shadow: #111 0px 0px 10px;
+  text-decoration: none;
+}
+
+.project_title:hover {
+  text-decoration: none;
 }
 
 #project_tagline {


### PR DESCRIPTION
REMReM Generate documentation was restructured.
Documentation was splitted into 3 paths.

1. Main page:
- Introduction
- Compatibility
- Components
- Installation
- Usage
- Logging

2. REMReM Publish CLI:
- Usage
- Examples

3. REMReM Publish Service:
- Configuration
- Usage
- Examples