### PR TITLE
Disable OpenAPI validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 2.1.23
+- Disable OpenAPI validation that relies on online validation tool
+
 ## 2.1.22
 - Fix configuration issue when executed with external Tomcat instance.
 

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     </parent>
 
     <properties>
-        <eiffel-remrem-generate.version>2.1.22</eiffel-remrem-generate.version>
+        <eiffel-remrem-generate.version>2.1.23</eiffel-remrem-generate.version>
         <eiffel-remrem-semantics.version>2.4.5</eiffel-remrem-semantics.version>
     </properties>
     <artifactId>eiffel-remrem-generate</artifactId>

--- a/service/src/main/resources/static/swagger-initializer.js
+++ b/service/src/main/resources/static/swagger-initializer.js
@@ -25,6 +25,7 @@ window.onload = function() {
     plugins: [
       SwaggerUIBundle.plugins.DownloadUrl
     ],
-    layout: "StandaloneLayout"
+    layout: "StandaloneLayout",
+    validatorUrl : null
   });
 };


### PR DESCRIPTION

### Applicable Issues
When hosted in an environment with no Internet access, the default validation of the OpenAPI specification fails because the validator is not reachable. As a consequence, an orange INVALID button appears in the web ui.

### Description of the Change
Disable the validation by setting the validatorUrl to null.

### Alternate Designs
Host a local validator in the same location where REMReM is hosted, and configure a local URL.


### Possible Drawbacks
Validation of the OpenAPI specification is missing.


### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Emelie Pettersson emelie.pettersson@ericsson.com
